### PR TITLE
Implement DescriptionOrName for all objects except ICase

### DIFF
--- a/SAP2000_Adapter/CRUD/Create/Material.cs
+++ b/SAP2000_Adapter/CRUD/Create/Material.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.Engine.Structure;
 
 namespace BH.Adapter.SAP2000
 {
@@ -40,24 +41,25 @@ namespace BH.Adapter.SAP2000
         private bool CreateObject(IMaterialFragment material)
         {
             eMatType matType = material.GetMaterialType();
+            string bhName = material.DescriptionOrName();
             int color = 0;
             string guid = "";
             string notes = "";
             string name = "";
 
-            if (m_model.PropMaterial.AddMaterial(ref name, matType, "United States", material.Name, material.Name, guid) == 0) //try to get the material from a dataset
+            if (m_model.PropMaterial.AddMaterial(ref name, matType, "United States", bhName, bhName, guid) == 0) //try to get the material from a dataset
             {
                 material.CustomData[AdapterIdName] = name;
             }
-            else if (m_model.PropMaterial.SetMaterial(material.Name, matType, color, notes, guid) == 0) //create the material
+            else if (m_model.PropMaterial.SetMaterial(bhName, matType, color, notes, guid) == 0) //create the material
             {
-                material.CustomData[AdapterIdName] = material.Name;
+                material.CustomData[AdapterIdName] = bhName;
 
                 if (material is IIsotropic)
                 {
                     IIsotropic isotropic = material as IIsotropic;
-                    if (m_model.PropMaterial.SetMPIsotropic(material.Name, isotropic.YoungsModulus, isotropic.PoissonsRatio, isotropic.ThermalExpansionCoeff) != 0)
-                        CreatePropertyWarning("Isotropy", "Material", material.Name);
+                    if (m_model.PropMaterial.SetMPIsotropic(bhName, isotropic.YoungsModulus, isotropic.PoissonsRatio, isotropic.ThermalExpansionCoeff) != 0)
+                        CreatePropertyWarning("Isotropy", "Material", bhName);
 
                 }
                 else if (material is IOrthotropic)
@@ -67,16 +69,16 @@ namespace BH.Adapter.SAP2000
                     double[] v = orthoTropic.PoissonsRatio.ToDoubleArray();
                     double[] a = orthoTropic.ThermalExpansionCoeff.ToDoubleArray();
                     double[] g = orthoTropic.ShearModulus.ToDoubleArray();
-                    if (m_model.PropMaterial.SetMPOrthotropic(material.Name, ref e, ref v, ref a, ref g) != 0)
-                        CreatePropertyWarning("Orthotropy", "Material", material.Name);
+                    if (m_model.PropMaterial.SetMPOrthotropic(bhName, ref e, ref v, ref a, ref g) != 0)
+                        CreatePropertyWarning("Orthotropy", "Material", bhName);
                 }
 
-                if (m_model.PropMaterial.SetWeightAndMass(material.Name, 2, material.Density) != 0)
-                    CreatePropertyWarning("Density", "Material", material.Name);
+                if (m_model.PropMaterial.SetWeightAndMass(bhName, 2, material.Density) != 0)
+                    CreatePropertyWarning("Density", "Material", bhName);
             }
             else
             {
-                CreateElementError("Material", material.Name);
+                CreateElementError("Material", bhName);
             }
 
             return true;

--- a/SAP2000_Adapter/CRUD/Create/Node.cs
+++ b/SAP2000_Adapter/CRUD/Create/Node.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.SAP2000
 
             if (m_model.PointObj.AddCartesian(bhNode.Position.X, bhNode.Position.Y, bhNode.Position.Z, ref name, bhNode.Name.ToString()) == 0)
             {
-                if (name != bhNode.Name)
+                if (name != bhNode.Name & bhNode.Name != "")
                     Engine.Reflection.Compute.RecordNote($"Node {bhNode.Name} was assigned {AdapterIdName} of {name}");
                 bhNode.CustomData[AdapterIdName] = name;
 

--- a/SAP2000_Adapter/CRUD/Create/RigidLink.cs
+++ b/SAP2000_Adapter/CRUD/Create/RigidLink.cs
@@ -33,7 +33,7 @@ namespace BH.Adapter.SAP2000
 
         private bool CreateObject(RigidLink bhLink)
         {
-            List < RigidLink> bhomLinks = BH.Engine.SAP2000.Query.SplitRigidLink(bhLink);
+            List<RigidLink> bhomLinks = BH.Engine.SAP2000.Query.SplitRigidLink(bhLink);
             List<string> linkIds = null;
 
             foreach (RigidLink link in bhomLinks)

--- a/SAP2000_Adapter/CRUD/Create/Section.cs
+++ b/SAP2000_Adapter/CRUD/Create/Section.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Physical.Materials;
+using BH.Engine.Structure;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
@@ -39,7 +40,7 @@ namespace BH.Adapter.SAP2000
         {
             if (SetSection(bhomSection as dynamic))
             {
-                bhomSection.CustomData[AdapterIdName] = bhomSection.Name;
+                bhomSection.CustomData[AdapterIdName] = bhomSection.DescriptionOrName();
                 return true;
             }
             else { return false; }
@@ -65,14 +66,15 @@ namespace BH.Adapter.SAP2000
 
         private bool SetSection(ConcreteSection bhomSection)
         {
-            return SetProfile(bhomSection.SectionProfile as dynamic, bhomSection.Name, bhomSection.Material);
+            return SetProfile(bhomSection.SectionProfile as dynamic, bhomSection.DescriptionOrName(), bhomSection.Material.CustomData[AdapterIdName].ToString());
         }
 
         /***************************************************/
 
         private bool SetSection(ExplicitSection bhomSection)
         {
-            int ret = m_model.PropFrame.SetGeneral(bhomSection.Name, bhomSection.Material.Name, bhomSection.CentreZ * 2, 
+            string matName = bhomSection.Material.CustomData[AdapterIdName].ToString();
+            int ret = m_model.PropFrame.SetGeneral(bhomSection.DescriptionOrName(), matName, bhomSection.CentreZ * 2, 
                 bhomSection.CentreY * 2, bhomSection.Area, bhomSection.Asy, bhomSection.Asz, bhomSection.J, 
                 bhomSection.Iy, bhomSection.Iz, bhomSection.Wply, bhomSection.Wplz, bhomSection.Wely, 
                 bhomSection.Wely, bhomSection.Rgy, bhomSection.Rgz);
@@ -83,65 +85,65 @@ namespace BH.Adapter.SAP2000
 
         private bool SetSection(SteelSection bhomSection)
         {
-            return SetProfile(bhomSection.SectionProfile as dynamic, bhomSection.Name, bhomSection.Material);
+            return SetProfile(bhomSection.SectionProfile as dynamic, bhomSection.DescriptionOrName(), bhomSection.Material.CustomData[AdapterIdName].ToString());
         }
 
         /***************************************************/
 
-        private bool SetProfile(AngleProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(AngleProfile bhomProfile, string sectionName, string matName)
         {
-            int ret = m_model.PropFrame.SetAngle(sectionName, material.Name, bhomProfile.Height, bhomProfile.Width, bhomProfile.FlangeThickness, bhomProfile.WebThickness);
+            int ret = m_model.PropFrame.SetAngle(sectionName, matName, bhomProfile.Height, bhomProfile.Width, bhomProfile.FlangeThickness, bhomProfile.WebThickness);
             return ret == 0;
         }
 
         /***************************************************/
 
-        private bool SetProfile(BoxProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(BoxProfile bhomProfile, string sectionName, string matName)
         {
-            int ret = m_model.PropFrame.SetTube(sectionName, material.Name, bhomProfile.Height, bhomProfile.Width, bhomProfile.Thickness, bhomProfile.Thickness);
+            int ret = m_model.PropFrame.SetTube(sectionName, matName, bhomProfile.Height, bhomProfile.Width, bhomProfile.Thickness, bhomProfile.Thickness);
             return ret == 0;
         }
 
         /***************************************************/
 
-        private bool SetProfile(ChannelProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(ChannelProfile bhomProfile, string sectionName, string matName)
         {
-            int ret = m_model.PropFrame.SetChannel(sectionName, material.Name, bhomProfile.Height, bhomProfile.FlangeWidth, bhomProfile.FlangeThickness, bhomProfile.WebThickness);
+            int ret = m_model.PropFrame.SetChannel(sectionName, matName, bhomProfile.Height, bhomProfile.FlangeWidth, bhomProfile.FlangeThickness, bhomProfile.WebThickness);
             return ret == 0;
         }
 
         /***************************************************/
 
-        private bool SetProfile(CircleProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(CircleProfile bhomProfile, string sectionName, string matName)
         {
-            int ret = m_model.PropFrame.SetCircle(sectionName, material.Name, bhomProfile.Diameter);
+            int ret = m_model.PropFrame.SetCircle(sectionName, matName, bhomProfile.Diameter);
             return ret == 0;
         }
 
         /***************************************************/
 
-        private bool SetProfile(FabricatedBoxProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(FabricatedBoxProfile bhomProfile, string sectionName, string matName)
         {
             if (bhomProfile.TopFlangeThickness != bhomProfile.BotFlangeThickness)
             {
-                CreatePropertyWarning(sectionName, "Fabricated Box with unequal flanges", bhomProfile.BHoM_Guid.ToString());                
+                CreatePropertyWarning(sectionName, "Fabricated Box with unequal flanges", bhomProfile.BHoM_Guid.ToString());
             }
             double tf = Math.Max(bhomProfile.TopFlangeThickness, bhomProfile.BotFlangeThickness);
-            int ret = m_model.PropFrame.SetTube(sectionName, material.Name, bhomProfile.Height, bhomProfile.Width, tf, bhomProfile.WebThickness);
+            int ret = m_model.PropFrame.SetTube(sectionName, matName, bhomProfile.Height, bhomProfile.Width, tf, bhomProfile.WebThickness);
             return ret == 0;
         }
 
         /***************************************************/
 
-        private bool SetProfile(FabricatedISectionProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(FabricatedISectionProfile bhomProfile, string sectionName, string matName)
         {
-            int ret = m_model.PropFrame.SetISection(sectionName, material.Name, bhomProfile.Height, bhomProfile.TopFlangeWidth, bhomProfile.TopFlangeThickness, bhomProfile.WebThickness, bhomProfile.BotFlangeWidth, bhomProfile.BotFlangeThickness);
+            int ret = m_model.PropFrame.SetISection(sectionName, matName, bhomProfile.Height, bhomProfile.TopFlangeWidth, bhomProfile.TopFlangeThickness, bhomProfile.WebThickness, bhomProfile.BotFlangeWidth, bhomProfile.BotFlangeThickness);
             return ret == 0;
         }
 
         /***************************************************/
 
-        private bool SetProfile(FreeFormProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(FreeFormProfile bhomProfile, string sectionName, string matName)
         {
             //Not implemented
             return false;
@@ -149,15 +151,15 @@ namespace BH.Adapter.SAP2000
 
         /***************************************************/
 
-        private bool SetProfile(ISectionProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(ISectionProfile bhomProfile, string sectionName, string matName)
         {
-            int ret = m_model.PropFrame.SetISection(sectionName, material.Name, bhomProfile.Height, bhomProfile.Width, bhomProfile.FlangeThickness, bhomProfile.WebThickness, bhomProfile.Width, bhomProfile.FlangeThickness);
+            int ret = m_model.PropFrame.SetISection(sectionName, matName, bhomProfile.Height, bhomProfile.Width, bhomProfile.FlangeThickness, bhomProfile.WebThickness, bhomProfile.Width, bhomProfile.FlangeThickness);
             return ret == 0;
         }
 
         /***************************************************/
 
-        private bool SetProfile(KiteProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(KiteProfile bhomProfile, string sectionName, string matName)
         {
             //Not implemented
             return false;
@@ -165,38 +167,38 @@ namespace BH.Adapter.SAP2000
 
         /***************************************************/
 
-        private bool SetProfile(RectangleProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(RectangleProfile bhomProfile, string sectionName, string matName)
         {
-            int ret = m_model.PropFrame.SetRectangle(sectionName, material.Name, bhomProfile.Height, bhomProfile.Width);
+            int ret = m_model.PropFrame.SetRectangle(sectionName, matName, bhomProfile.Height, bhomProfile.Width);
             return ret == 0;
         }
 
         /***************************************************/
 
-        private bool SetProfile(TSectionProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(TSectionProfile bhomProfile, string sectionName, string matName)
         {
-            int ret = m_model.PropFrame.SetTee(sectionName, material.Name, bhomProfile.Height, bhomProfile.Width, bhomProfile.FlangeThickness, bhomProfile.WebThickness);
+            int ret = m_model.PropFrame.SetTee(sectionName, matName, bhomProfile.Height, bhomProfile.Width, bhomProfile.FlangeThickness, bhomProfile.WebThickness);
             return ret == 0;
         }
 
         /***************************************************/
 
-        private bool SetProfile(ZSectionProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(ZSectionProfile bhomProfile, string sectionName, string matName)
         {
             if (bhomProfile.FlangeThickness != bhomProfile.WebThickness)
             {
                 CreatePropertyWarning(sectionName, "Z Section with unequal web and flange thickness", bhomProfile.BHoM_Guid.ToString());
             }
             double t = Math.Max(bhomProfile.FlangeThickness, bhomProfile.WebThickness);
-            int ret = m_model.PropFrame.SetColdZ(sectionName, material.Name, bhomProfile.Height, bhomProfile.FlangeWidth, t, bhomProfile.RootRadius, 0, 0);
+            int ret = m_model.PropFrame.SetColdZ(sectionName, matName, bhomProfile.Height, bhomProfile.FlangeWidth, t, bhomProfile.RootRadius, 0, 0);
             return ret == 0;
         }
 
         /***************************************************/
 
-        private bool SetProfile(TubeProfile bhomProfile, string sectionName, IMaterialFragment material)
+        private bool SetProfile(TubeProfile bhomProfile, string sectionName, string matName)
         {
-            int ret = m_model.PropFrame.SetPipe(sectionName, material.Name, bhomProfile.Diameter, bhomProfile.Thickness);
+            int ret = m_model.PropFrame.SetPipe(sectionName, matName, bhomProfile.Diameter, bhomProfile.Thickness);
             return ret == 0;
         }
 

--- a/SAP2000_Adapter/CRUD/Create/Section.cs
+++ b/SAP2000_Adapter/CRUD/Create/Section.cs
@@ -52,6 +52,10 @@ namespace BH.Adapter.SAP2000
 
         private bool SetSection(CableSection bhomSection)
         {
+            string name = bhomSection.DescriptionOrName();
+            string matName = bhomSection.Material.CustomData[AdapterIdName].ToString();
+            if (m_model.PropCable.SetProp(name, matName, bhomSection.Area) != 0)
+                Engine.Reflection.Compute.RecordError($"Could not create Cable section with name {name}");
             return false;
         }
 
@@ -71,6 +75,27 @@ namespace BH.Adapter.SAP2000
 
         /***************************************************/
 
+        private bool SetSection(TimberSection bhomSection)
+        {
+            return SetProfile(bhomSection.SectionProfile as dynamic, bhomSection.DescriptionOrName(), bhomSection.Material.CustomData[AdapterIdName].ToString());
+        }
+
+        /***************************************************/
+
+        private bool SetSection(SteelSection bhomSection)
+        {
+            return SetProfile(bhomSection.SectionProfile as dynamic, bhomSection.DescriptionOrName(), bhomSection.Material.CustomData[AdapterIdName].ToString());
+        }
+
+        /***************************************************/
+
+        private bool SetSection(AluminiumSection bhomSection)
+        {
+            return SetProfile(bhomSection.SectionProfile as dynamic, bhomSection.DescriptionOrName(), bhomSection.Material.CustomData[AdapterIdName].ToString());
+        }
+
+        /***************************************************/
+
         private bool SetSection(ExplicitSection bhomSection)
         {
             string matName = bhomSection.Material.CustomData[AdapterIdName].ToString();
@@ -79,13 +104,6 @@ namespace BH.Adapter.SAP2000
                 bhomSection.Iy, bhomSection.Iz, bhomSection.Wply, bhomSection.Wplz, bhomSection.Wely, 
                 bhomSection.Wely, bhomSection.Rgy, bhomSection.Rgz);
             return ret == 0;
-        }
-
-        /***************************************************/
-
-        private bool SetSection(SteelSection bhomSection)
-        {
-            return SetProfile(bhomSection.SectionProfile as dynamic, bhomSection.DescriptionOrName(), bhomSection.Material.CustomData[AdapterIdName].ToString());
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/CRUD/Create/SurfaceProperty.cs
+++ b/SAP2000_Adapter/CRUD/Create/SurfaceProperty.cs
@@ -32,40 +32,40 @@ namespace BH.Adapter.SAP2000
         /***************************************************/
         private bool CreateObject(ISurfaceProperty surfaceProperty)
         {
-            string materialName = surfaceProperty.Material.CustomData[AdapterIdName].ToString();
+            string propName = surfaceProperty.DescriptionOrName();
+            string matName = surfaceProperty.Material.CustomData[AdapterIdName].ToString();
 
             if (surfaceProperty.GetType() == typeof(Waffle))
             {
                 // not implemented!
-                CreatePropertyError("Waffle Not Implemented!", "Panel", surfaceProperty.Name);
+                CreatePropertyError("Waffle Not Implemented!", "Panel", propName);
             }
             else if (surfaceProperty.GetType() == typeof(Ribbed))
             {
                 // not implemented!
-                CreatePropertyError("Ribbed Not Implemented!", "Panel", surfaceProperty.Name);
+                CreatePropertyError("Ribbed Not Implemented!", "Panel", propName);
             }
             else if (surfaceProperty.GetType() == typeof(LoadingPanelProperty))
             {
                 // not implemented!
-                CreatePropertyError("Loading Panel Not Implemented!", "Panel", surfaceProperty.Name);
+                CreatePropertyError("Loading Panel Not Implemented!", "Panel", propName);
             }
             else if (surfaceProperty.GetType() == typeof(ConstantThickness))
             {
                 ConstantThickness constantThickness = (ConstantThickness)surfaceProperty;
                 int shellType = 1;
                 bool includeDrillingDOF = true;
-                string material = constantThickness.Material.CustomData[AdapterIdName].ToString();
-                if (m_model.PropArea.SetShell_1(surfaceProperty.Name, shellType, includeDrillingDOF, material, 0, constantThickness.Thickness, constantThickness.Thickness) != 0)
-                    CreatePropertyError("ConstantThickness", "SurfaceProperty", surfaceProperty.Name);
+                if (m_model.PropArea.SetShell_1(propName, shellType, includeDrillingDOF, matName, 0, constantThickness.Thickness, constantThickness.Thickness) != 0)
+                    CreatePropertyError("ConstantThickness", "SurfaceProperty", propName);
             }
 
-            surfaceProperty.CustomData[AdapterIdName] = surfaceProperty.Name;
+            surfaceProperty.CustomData[AdapterIdName] = propName;
 
             if (surfaceProperty.HasModifiers())
             {
                 double[] modifier = surfaceProperty.Modifiers();//(double[])surfaceProperty.CustomData["Modifiers"];
-                if (m_model.PropArea.SetModifiers(surfaceProperty.Name, ref modifier) != 0)
-                    CreatePropertyError("Modifiers", "SurfaceProperty", surfaceProperty.Name);
+                if (m_model.PropArea.SetModifiers(propName, ref modifier) != 0)
+                    CreatePropertyError("Modifiers", "SurfaceProperty", propName);
             }
 
             return true;

--- a/SAP2000_Adapter/CRUD/Read/Material.cs
+++ b/SAP2000_Adapter/CRUD/Read/Material.cs
@@ -77,7 +77,7 @@ namespace BH.Adapter.SAP2000
                     }
                     else if (symType == 1) // Orthotropic
                     {
-                        m_model.PropMaterial.GetMPOrthotropic(materialName, ref E, ref V, ref ThermCo, ref G);
+                        m_model.PropMaterial.GetMPOrthotropic(materialName, ref E, ref V, ref ThermCo, ref G);                        
                     }
                     else if (symType == 2) //Anisotropic
                     {
@@ -134,6 +134,23 @@ namespace BH.Adapter.SAP2000
                         case eMatType.Tendon:
                             m_model.PropMaterial.GetOTendon(materialName, ref fy, ref fu, ref i0, ref i1);
                             m = Engine.Structure.Create.Steel(materialName, e, v, thermCo, mass, 0, fy, fu);
+                            break;
+                        case eMatType.NoDesign:
+                            switch (symType)
+                            {
+                                case 0: 
+                                    m = new GenericIsotropicMaterial() { Name = materialName, YoungsModulus = e, PoissonsRatio = v, ThermalExpansionCoeff = thermCo, Density = mass };
+                                    break;
+                                case 1:
+                                    m = new GenericOrthotropicMaterial() { Name = materialName, YoungsModulus = E.ToVector(), PoissonsRatio = V.ToVector(), ThermalExpansionCoeff = ThermCo.ToVector(), Density = mass };
+                                    break;
+                                case 2:
+                                case 3:
+                                default:
+                                    m = Engine.Structure.Create.Steel(materialName);
+                                    Engine.Reflection.Compute.RecordWarning("Could not extract structural properties for material " + materialName);
+                                    break;
+                            }
                             break;
                         default:
                             m = Engine.Structure.Create.Steel(materialName);

--- a/SAP2000_Adapter/CRUD/Read/Section.cs
+++ b/SAP2000_Adapter/CRUD/Read/Section.cs
@@ -126,66 +126,38 @@ namespace BH.Adapter.SAP2000
                         m_model.PropFrame.GetGeneral(id, ref fileName, ref materialName, ref t3, ref t2, ref Area, ref As2, ref As3, ref Torsion, ref I22, ref I33, ref S22, ref S33, ref Z22, ref Z33, ref R22, ref R33, ref color, ref notes, ref guid);
                         constructor = "explicit";
                         break;
-                    case eFramePropType.DbChannel:                        
-                        break;
-                    case eFramePropType.SD:                        
-                        break;
-                    case eFramePropType.Variable:                        
-                        break;
-                    case eFramePropType.Joist:                        
-                        break;
-                    case eFramePropType.Bridge:                        
-                        break;
-                    case eFramePropType.Cold_C:                        
-                        break;
-                    case eFramePropType.Cold_2C:                        
-                        break;
                     case eFramePropType.Cold_Z:
                         m_model.PropFrame.GetColdZ(id, ref fileName, ref materialName, ref t3, ref t2, ref tw, ref radius, ref tfb, ref angle, ref color, ref notes, ref guid);
                         bhomProfile = BH.Engine.Geometry.Create.ZSectionProfile(t3, t2, tw, tw, radius, 0);
                         break;
-                    case eFramePropType.Cold_L:                        
-                        break;
-                    case eFramePropType.Cold_2L:                        
-                        break;
-                    case eFramePropType.Cold_Hat:                        
-                        break;
-                    case eFramePropType.BuiltupICoverplate:                        
-                        break;
-                    case eFramePropType.PCCGirderI:                        
-                        break;
-                    case eFramePropType.PCCGirderU:                        
-                        break;
-                    case eFramePropType.BuiltupIHybrid:                        
-                        break;
-                    case eFramePropType.BuiltupUHybrid:                        
-                        break;
-                    case eFramePropType.Concrete_L:                        
-                        break;
-                    case eFramePropType.FilledTube:                        
-                        break;
-                    case eFramePropType.FilledPipe:                        
-                        break;
-                    case eFramePropType.EncasedRectangle:                        
-                        break;
-                    case eFramePropType.EncasedCircle:                        
-                        break;
+                    case eFramePropType.DbChannel:
+                    case eFramePropType.SD:
+                    case eFramePropType.Variable:
+                    case eFramePropType.Joist:
+                    case eFramePropType.Bridge:
+                    case eFramePropType.Cold_C:
+                    case eFramePropType.Cold_2C:
+                    case eFramePropType.Cold_L:
+                    case eFramePropType.Cold_2L:
+                    case eFramePropType.Cold_Hat:
+                    case eFramePropType.BuiltupICoverplate:
+                    case eFramePropType.PCCGirderI:
+                    case eFramePropType.PCCGirderU:
+                    case eFramePropType.BuiltupIHybrid:
+                    case eFramePropType.BuiltupUHybrid:
+                    case eFramePropType.Concrete_L:
+                    case eFramePropType.FilledTube:
+                    case eFramePropType.FilledPipe:
+                    case eFramePropType.EncasedRectangle:
+                    case eFramePropType.EncasedCircle:
                     case eFramePropType.BucklingRestrainedBrace:
-                        break;
                     case eFramePropType.CoreBrace_BRB:
-                        break;
                     case eFramePropType.ConcreteTee:
-                        break;
                     case eFramePropType.ConcreteBox:
-                        break;
                     case eFramePropType.ConcretePipe:
-                        break;
                     case eFramePropType.ConcreteCross:
-                        break;
                     case eFramePropType.SteelPlate:
-                        break;
                     case eFramePropType.SteelRod:
-                        break;
                     default:                        
                         break;
                 }
@@ -228,18 +200,25 @@ namespace BH.Adapter.SAP2000
                         };
                         break;
                     case "standard":
-                        if (material is Aluminium || material is Steel)
+                        if (material is Steel)
                         {
                             bhomProperty = BH.Engine.Structure.Create.SteelSectionFromProfile(bhomProfile);
+                        }
+                        if (material is Aluminium)
+                        {
+                            bhomProperty = BH.Engine.Structure.Create.AluminiumSectionFromProfile(bhomProfile);
                         }
                         else if (material is Concrete)
                         {
                             bhomProperty = BH.Engine.Structure.Create.ConcreteSectionFromProfile(bhomProfile);
                         }
+                        else if (material is Timber)
+                        {
+                            bhomProperty = BH.Engine.Structure.Create.TimberSectionFromProfile(bhomProfile);
+                        }
                         else
                         {
-                            bhomProperty = BH.Engine.Structure.Create.SteelSectionFromProfile(bhomProfile);
-                            Engine.Reflection.Compute.RecordWarning("Reading sections of material type " + material.GetType().Name + "is not supported. Section with name " + id + " will be returned as a steel section");
+                            bhomProperty = BH.Engine.Structure.Create.GenericSectionFromProfile(bhomProfile);
                         }
                         break;
                 }

--- a/SAP2000_Adapter/Convert/ToBHoM/Material.cs
+++ b/SAP2000_Adapter/Convert/ToBHoM/Material.cs
@@ -35,13 +35,27 @@ namespace BH.Adapter.SAP2000
     {
         /***************************************************/
         /**** Public Methods                            ****/
+        /***************************************************/
 
+        public static eMatType GetMaterialType(this IMaterialFragment material)
+        {
+            if (material is Steel)
+                return eMatType.Steel;
+            else if (material is Concrete)
+                return eMatType.Concrete;
+            else if (material is Aluminium)
+                return eMatType.Aluminum;
+            else if (material is Timber)
+                return eMatType.NoDesign;
+            else
+                return eMatType.NoDesign;
+        }
 
         /***************************************************/
 
-        public static Vector ToVector(this double[] darray)
+        public static double[] ToDoubleArray(this Vector v)
         {
-            return new Vector() { X = darray[0], Y = darray[1], Z = darray[2] };
+            return new double[] { v.X, v.Y, v.Z };
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/SAP2000_Adapter.csproj
+++ b/SAP2000_Adapter/SAP2000_Adapter.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Convert\ToBHoM\Bar.cs" />
     <Compile Include="Convert\ToBHoM\Constraint.cs" />
     <Compile Include="Convert\ToBHoM\Loads.cs" />
+    <Compile Include="Convert\ToBHoM\Material.cs" />
     <Compile Include="Convert\ToSAP2000\Bar.cs" />
     <Compile Include="Convert\ToSAP2000\Constraint.cs" />
     <Compile Include="Convert\ToSAP2000\Loads.cs" />

--- a/SAP2000_Adapter/Types/SetupComparer.cs
+++ b/SAP2000_Adapter/Types/SetupComparer.cs
@@ -29,6 +29,7 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Loads;
 using System;
 using System.Collections.Generic;
+using BH.Engine.Structure;
 
 namespace BH.Adapter.SAP2000
 {
@@ -39,7 +40,7 @@ namespace BH.Adapter.SAP2000
         /***************************************************/
         
         //Compares nodes by distance (down to 3 decimal places -> mm)
-        //Compares Materials, SectionProprties, LinkConstraints, and Property2D by name
+        //Compares Materials, SectionProperties, LinkConstraints, and Property2D by name
         //Add/remove any type in the dictionary below that you want (or not) a specific comparison method for.
 
         private void SetupComparers()
@@ -47,11 +48,11 @@ namespace BH.Adapter.SAP2000
             AdapterComparers = new Dictionary<Type, object>
             {
                 {typeof(Node), new BH.Engine.Structure.NodeDistanceComparer(3) },   //The 3 in here sets how many decimal places to look at for node merging. 3 decimal places gives mm precision
-                {typeof(ISectionProperty), new BHoMObjectNameOrToStringComparer() },
-                {typeof(IMaterialFragment), new BHoMObjectNameComparer() },
-                {typeof(LinkConstraint), new BHoMObjectNameComparer() },
-                {typeof(ISurfaceProperty), new BHoMObjectNameComparer() },
-                {typeof(ICase), new BHoMObjectNameComparer() },
+                {typeof(ISectionProperty), new NameOrDescriptionComparer() },
+                {typeof(IMaterialFragment), new NameOrDescriptionComparer() },
+                {typeof(LinkConstraint), new NameOrDescriptionComparer() },
+                {typeof(ISurfaceProperty), new NameOrDescriptionComparer() },
+                {typeof(ICase), new BHoMObjectNameComparer() }, 
             };
         }
 

--- a/SAP2000_Adapter/Types/SetupComparer.cs
+++ b/SAP2000_Adapter/Types/SetupComparer.cs
@@ -47,7 +47,7 @@ namespace BH.Adapter.SAP2000
         {
             AdapterComparers = new Dictionary<Type, object>
             {
-                {typeof(Node), new BH.Engine.Structure.NodeDistanceComparer(3) },   //The 3 in here sets how many decimal places to look at for node merging. 3 decimal places gives mm precision
+                {typeof(Node), new NodeDistanceComparer(3) },   //The 3 in here sets how many decimal places to look at for node merging. 3 decimal places gives mm precision
                 {typeof(ISectionProperty), new NameOrDescriptionComparer() },
                 {typeof(IMaterialFragment), new NameOrDescriptionComparer() },
                 {typeof(LinkConstraint), new NameOrDescriptionComparer() },

--- a/SAP2000_oM/Enums/SDShapeType.cs
+++ b/SAP2000_oM/Enums/SDShapeType.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -20,30 +20,40 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.oM.Structure.MaterialFragments;
-using BH.oM.Geometry;
-using SAP2000v1;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BH.Adapter.SAP2000
+namespace BH.oM.Adapters.SAP2000
 {
-    public static partial class Convert
+
+    /***************************************************/
+    /**** Public Enums                              ****/
+    /***************************************************/
+
+    public enum SDShapeType
     {
-        /***************************************************/
-        /**** Public Methods                            ****/
-
-
-        /***************************************************/
-
-        public static Vector ToVector(this double[] darray)
-        {
-            return new Vector() { X = darray[0], Y = darray[1], Z = darray[2] };
-        }
-
-        /***************************************************/
+        ISection = 1,
+        Channel = 2,
+        Tee = 3,
+        Angle = 4,
+        DoubleAngle = 5,
+        Box = 6,
+        Pipe = 7,
+        Plate = 8,
+        SolidRectangle = 101,
+        SolidCircle = 102,
+        SolidSegment = 103,
+        SolidSector = 104,
+        Polygon = 201,
+        ReinforcingSingle = 301,
+        ReinforcingLine = 302,
+        ReinforcingRectangle = 303,
+        ReinforcingCircle = 304,
+        ReferenceLine = 401,
+        ReferenceCircle = 402,
+        CaltransSquare = 501,
+        CaltransCircle = 502,
+        CaltransHexagon = 503,
+        CaltransOctagon = 504,
     }
+
+    /***************************************************/
+
 }

--- a/SAP2000_oM/SAP2000_oM.csproj
+++ b/SAP2000_oM/SAP2000_oM.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Config\SAP2000ActionConfig.cs" />
+    <Compile Include="Enums\SDShapeType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Enums\ShellType.cs" />
   </ItemGroup>


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #94 
Closes #64 

Implemented DescriptionOrName() for pushing materials, section properties, and surface properties with no name defined.

Implemented NameOrDescription comparer for Material, SectionProperty, SurfaceProperty, and ICase.


### Test files
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FSAP2000%5FToolkit%2FIssue94%20DescriptionOrName&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4

https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FSAP2000%5FToolkit%2FIssue64%20Support%20for%20timberm%20aluminum%2C%20generic

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->