### PR TITLE
Groups from tags

### DIFF
--- a/SAP2000_Adapter/CRUD/Create/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Create/Bar.cs
@@ -75,11 +75,21 @@ namespace BH.Adapter.SAP2000
                     }
                 }
 
-                else if (bhBar.Offset != null)
+                if (bhBar.Offset != null)
                 {
                     if (m_model.FrameObj.SetEndLengthOffset(name, false, -1 * (bhBar.Offset.Start.X), bhBar.Offset.End.X, 1) != 0)
                     {
                         CreatePropertyWarning("Length offset", "Bar", name);
+                    }
+                }
+
+                foreach (string gName in bhBar.Tags)
+                {
+                    string groupName = gName.ToString();
+                    if (m_model.FrameObj.SetGroupAssign(name, groupName) != 0)
+                    {
+                        m_model.GroupDef.SetGroup(groupName);
+                        m_model.FrameObj.SetGroupAssign(name, groupName);
                     }
                 }
             }

--- a/SAP2000_Adapter/CRUD/Create/Node.cs
+++ b/SAP2000_Adapter/CRUD/Create/Node.cs
@@ -72,6 +72,16 @@ namespace BH.Adapter.SAP2000
                     if (m_model.PointObj.SetSpring(name, ref spring) != 0)
                         CreatePropertyWarning("Node Spring", "Node", name);
                 }
+
+                foreach (string gName in bhNode.Tags)
+                {
+                    string groupName = gName.ToString();
+                    if (m_model.PointObj.SetGroupAssign(name, groupName) != 0)
+                    {
+                        m_model.GroupDef.SetGroup(groupName);
+                        m_model.PointObj.SetGroupAssign(name, groupName);
+                    }
+                }
             }
 
             return true;

--- a/SAP2000_Adapter/CRUD/Create/Panel.cs
+++ b/SAP2000_Adapter/CRUD/Create/Panel.cs
@@ -60,6 +60,16 @@ namespace BH.Adapter.SAP2000
             else
                 CreateElementError("Panel", bhPanel.Name);
 
+            foreach (string gName in bhPanel.Tags)
+            {
+                string groupName = gName.ToString();
+                if (m_model.AreaObj.SetGroupAssign(name, groupName) != 0)
+                {
+                    m_model.GroupDef.SetGroup(groupName);
+                    m_model.AreaObj.SetGroupAssign(name, groupName);
+                }
+            }
+
             return true;
         }
 

--- a/SAP2000_Adapter/CRUD/Create/RigidLink.cs
+++ b/SAP2000_Adapter/CRUD/Create/RigidLink.cs
@@ -47,7 +47,17 @@ namespace BH.Adapter.SAP2000
                 {
                     CreateElementError("RigidLink", name);
                 }
-                
+
+                foreach (string gName in bhLink.Tags)
+                {
+                    string groupName = gName.ToString();
+                    if (m_model.LinkObj.SetGroupAssign(name, groupName) != 0)
+                    {
+                        m_model.GroupDef.SetGroup(groupName);
+                        m_model.LinkObj.SetGroupAssign(name, groupName);
+                    }
+                }
+
                 linkIds.Add(name);
             }
 

--- a/SAP2000_Adapter/CRUD/Read/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Read/Bar.cs
@@ -100,7 +100,14 @@ namespace BH.Adapter.SAP2000
                         Engine.Reflection.Compute.RecordWarning("Could not get local axes for bar " + id + ". Orientation angle is 0 by default");
                     }
 
-                    
+                    int numGroups = 0;
+                    string[] groupNames = new string[0];
+                    if (m_model.FrameObj.GetGroupAssign(id, ref numGroups, ref groupNames) == 0)
+                    {
+                        foreach (string grpName in groupNames)
+                            bhomBar.Tags.Add(grpName);
+                    }
+
                     bhomBars.Add(bhomBar);
                 }
                 catch


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #97

Mapped BHoM Tags to SAP Groups. 
- On Push, if objects are tagged, a group will be created if it doesn't already exist, and the object will be added to the group. 
- On Pull, all groups the SAP object belongs to will be added to the tags for the resulting BHoM object.

### Test files
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FSAP2000%5FToolkit%2FIssue97%20Push%20Groups&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->