### PR TITLE
Return XY basis if node is not oriented to Global Coordinates.

### DIFF
--- a/SAP2000_Adapter/CRUD/Read/Node.cs
+++ b/SAP2000_Adapter/CRUD/Read/Node.cs
@@ -112,7 +112,10 @@ namespace BH.Adapter.SAP2000
                     ref myPlVectOpt, ref myPlCSys, ref myPlDir, ref myPlPt, ref myPlVect);
 
                 if (myAxCSys != "GLOBAL" || myPlCSys != "GLOBAL")
-                    Engine.Reflection.Compute.RecordWarning("No support for reading node orientations not in Global Coordinates. Check results carefully");
+                {
+                    Engine.Reflection.Compute.RecordWarning("No support for reading node orientations not in Global Coordinates. Node orientation set to default");
+                    return basis;
+                }
 
                 Vector vec1 = null;
                 Vector vec2 = null;


### PR DESCRIPTION


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #124 

<!-- Add short description of what has been fixed -->
Return xy orientation for nodes when they are defined in an unsupported coordinate system, rather than failing in the push

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/SAP2000_Toolkit/091%20-%20Issue%20-%20Support%20Node%20Orientation?csf=1&web=1&e=E9i3og

Use with accompanying SAP file, or create a new SAP model with a node with advanced local axes defined by a non-global coordinate system.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->