### PR TITLE
Sap2000 toolkit #112 map groups to tags

### DIFF
--- a/SAP2000_Adapter/CRUD/Read/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Read/Bar.cs
@@ -102,6 +102,7 @@ namespace BH.Adapter.SAP2000
                         Engine.Reflection.Compute.RecordWarning("Could not get local axes for bar " + id + ". Orientation angle is 0 by default");
                     }
 
+                    // Get the groups the bar is assigned to
                     int numGroups = 0;
                     string[] groupNames = new string[0];
                     if (m_model.FrameObj.GetGroupAssign(id, ref numGroups, ref groupNames) == 0)

--- a/SAP2000_Adapter/CRUD/Read/Node.cs
+++ b/SAP2000_Adapter/CRUD/Read/Node.cs
@@ -63,6 +63,7 @@ namespace BH.Adapter.SAP2000
 
                 bhNode.Support = ReadNodeSupport(id);
 
+                // Get the groups the node is assigned to
                 int numGroups = 0;
                 string[] groupNames = new string[0];
                 if (m_model.PointObj.GetGroupAssign(id, ref numGroups, ref groupNames) == 0)

--- a/SAP2000_Adapter/CRUD/Read/Node.cs
+++ b/SAP2000_Adapter/CRUD/Read/Node.cs
@@ -63,7 +63,16 @@ namespace BH.Adapter.SAP2000
 
                 bhNode.Support = ReadNodeSupport(id);
 
-                nodeList.Add(bhNode);                
+                int numGroups = 0;
+                string[] groupNames = new string[0];
+                if (m_model.PointObj.GetGroupAssign(id, ref numGroups, ref groupNames) == 0)
+                {
+                    foreach (string grpName in groupNames)
+                        bhNode.Tags.Add(grpName);
+                }
+
+                nodeList.Add(bhNode); 
+                
             }
 
             return nodeList;

--- a/SAP2000_Adapter/CRUD/Read/Panel.cs
+++ b/SAP2000_Adapter/CRUD/Read/Panel.cs
@@ -87,6 +87,13 @@ namespace BH.Adapter.SAP2000
                     bhomPanel.Property = bhProp;
                 }
 
+                int numGroups = 0;
+                string[] groupNames = new string[0];
+                if (m_model.AreaObj.GetGroupAssign(id, ref numGroups, ref groupNames) == 0)
+                {
+                    foreach (string grpName in groupNames)
+                        bhomPanel.Tags.Add(grpName);
+                }
 
                 //Add the panel to the list
                 bhomPanels.Add(bhomPanel);

--- a/SAP2000_Adapter/CRUD/Read/Panel.cs
+++ b/SAP2000_Adapter/CRUD/Read/Panel.cs
@@ -87,6 +87,7 @@ namespace BH.Adapter.SAP2000
                     bhomPanel.Property = bhProp;
                 }
 
+                //Get the groups the panel is assigned to
                 int numGroups = 0;
                 string[] groupNames = new string[0];
                 if (m_model.AreaObj.GetGroupAssign(id, ref numGroups, ref groupNames) == 0)

--- a/SAP2000_Adapter/CRUD/Read/RigidLink.cs
+++ b/SAP2000_Adapter/CRUD/Read/RigidLink.cs
@@ -62,6 +62,13 @@ namespace BH.Adapter.SAP2000
                 bhomLinkConstraints.TryGetValue(propName, out bhProp);
                 newLink.Constraint = bhProp;
 
+                int numGroups = 0;
+                string[] groupNames = new string[0];
+                if (m_model.LinkObj.GetGroupAssign(name, ref numGroups, ref groupNames) == 0)
+                {
+                    foreach (string grpName in groupNames)
+                        newLink.Tags.Add(grpName);
+                }
                 linkList.Add(newLink);
             }
 

--- a/SAP2000_Adapter/CRUD/Read/RigidLink.cs
+++ b/SAP2000_Adapter/CRUD/Read/RigidLink.cs
@@ -62,6 +62,7 @@ namespace BH.Adapter.SAP2000
                 bhomLinkConstraints.TryGetValue(propName, out bhProp);
                 newLink.Constraint = bhProp;
 
+                // Get the groups the link is assigned to
                 int numGroups = 0;
                 string[] groupNames = new string[0];
                 if (m_model.LinkObj.GetGroupAssign(name, ref numGroups, ref groupNames) == 0)


### PR DESCRIPTION

 ### Issues addressed by this PR

Closes #112 

Adds pulling by group support for the following BHoM implemented types in SAP2000: Node, RigidLink, Bar, Panel (Other types available in SAP2000 API, tendon and cable, but not implemented in SAP2000 Toolkit yet)


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/SAP2000_Toolkit/112%20-%20PR%20-%20Map%20Groups%20to%20Tags?csf=1&web=1&e=wAL6A3

