### PR TITLE
Remove support for pulling results with filter request, adding error messaging

### DIFF
--- a/SAP2000_Adapter/CRUD/Read/Results/Result.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/Result.cs
@@ -11,16 +11,8 @@ namespace BH.Adapter.SAP2000
 {
     public partial class SAP2000Adapter : BHoMAdapter
     {
-        protected override IEnumerable<IResult> ReadResults(Type type, IList ids = null, IList cases = null, int divisions = 5, ActionConfig actionConfig = null)
-        {
-            IResultRequest request = Engine.Structure.Create.IResultRequest(type, ids?.Cast<object>(), cases?.Cast<object>(), divisions);
-
-            if (request != null)
-                return this.ReadResults(request as dynamic);
-            else
-                return new List<IResult>();
-        }
-
+        /***************************************************/
+        /**** Private Methods                           ****/
         /***************************************************/
 
         private List<string> CheckAndSetUpCases(IResultRequest request)

--- a/SAP2000_Adapter/CRUD/Read/_IRead.cs
+++ b/SAP2000_Adapter/CRUD/Read/_IRead.cs
@@ -32,6 +32,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Adapter;
+using BH.oM.Analytical.Results;
+using BH.oM.Structure.Results;
+using BH.oM.Structure.Requests;
 
 namespace BH.Adapter.SAP2000
 {
@@ -65,6 +68,11 @@ namespace BH.Adapter.SAP2000
                 return ReadRigidLink(ids as dynamic);
             else if (type == typeof(LinkConstraint))
                 return ReadLinkConstraints(ids as dynamic);
+            else if (typeof(IResult).IsAssignableFrom(type))
+            {
+                Modules.Structure.ErrorMessages.ReadResultsError(type);
+                return null;
+            }
 
 
             return null;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 

[BHoM/BHoM_Adapter#244](https://github.com/BHoM/BHoM_Adapter/pull/244)

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #128 

Removing support for pulling results with filter request, instead raising error stating what request that should be used.



### Test files

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/SAP2000_Toolkit/128%20-%20Issue%20-%20Remove%20Support%20for%20Pulling%20Results%20with%20Filter%20Request?csf=1&web=1&e=8AUxGS

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->