### PR TITLE
Renamed RigidLink master/slave to primary/secondary

### DIFF
--- a/SAP2000_Adapter/CRUD/Create/RigidLink.cs
+++ b/SAP2000_Adapter/CRUD/Create/RigidLink.cs
@@ -42,10 +42,10 @@ namespace BH.Adapter.SAP2000
             foreach (RigidLink subLink in subLinks)
             {
                 string name = "";
-                string masterNode = subLink.MasterNode.CustomData[AdapterIdName].ToString();
-                string slaveNode = subLink.SlaveNodes[0].CustomData[AdapterIdName].ToString();
+                string primaryNode = subLink.PrimaryNode.CustomData[AdapterIdName].ToString();
+                string secondaryNode = subLink.SecondaryNodes[0].CustomData[AdapterIdName].ToString();
 
-                if (m_model.LinkObj.AddByPoint(masterNode, slaveNode, ref name, false, "Default", subLink.Name) == 0)
+                if (m_model.LinkObj.AddByPoint(primaryNode, secondaryNode, ref name, false, "Default", subLink.Name) == 0)
                 {
                     //Check if SAP respected the link name.
                     if (subLink.Name != "" && subLink.Name != name)

--- a/SAP2000_Adapter/CRUD/Read/RigidLink.cs
+++ b/SAP2000_Adapter/CRUD/Read/RigidLink.cs
@@ -50,12 +50,12 @@ namespace BH.Adapter.SAP2000
 
                 newLink.CustomData[AdapterIdName] = newLink.Name = name;
 
-                string masterId = "";
-                string SlaveId = "";
+                string primaryId = "";
+                string secondaryId = "";
                 string propName = "";
-                m_model.LinkObj.GetPoints(name, ref masterId, ref SlaveId);
-                newLink.MasterNode = bhomNodes[masterId];
-                newLink.SlaveNodes = new List<Node> { bhomNodes[SlaveId] };
+                m_model.LinkObj.GetPoints(name, ref primaryId, ref secondaryId);
+                newLink.PrimaryNode = bhomNodes[primaryId];
+                newLink.SecondaryNodes = new List<Node> { bhomNodes[secondaryId] };
 
                 m_model.LinkObj.GetProperty(name, ref propName);
                 LinkConstraint bhProp = new LinkConstraint();

--- a/SAP2000_Engine/Query/JoinRigidLink.cs
+++ b/SAP2000_Engine/Query/JoinRigidLink.cs
@@ -48,7 +48,7 @@ namespace BH.Engine.Adapters.SAP2000
                     string JoinedName = nameParts[0];
                     if (joinedList.ContainsKey(JoinedName))
                     {
-                        joinedList[JoinedName].SlaveNodes.Add(link.SlaveNodes[0]);
+                        joinedList[JoinedName].SecondaryNodes.Add(link.SecondaryNodes[0]);
                     }
                     else
                     {

--- a/SAP2000_Engine/Query/SplitRigidLink.cs
+++ b/SAP2000_Engine/Query/SplitRigidLink.cs
@@ -38,16 +38,16 @@ namespace BH.Engine.Adapters.SAP2000
         {
             List<RigidLink> singleLinks = new List<RigidLink>();
 
-            if (link.SlaveNodes.Count() <= 1)
+            if (link.SecondaryNodes.Count() <= 1)
             {
                 singleLinks.Add(link);
             }
             else
             {
-                for (int i = 0; i < link.SlaveNodes.Count(); i++)
+                for (int i = 0; i < link.SecondaryNodes.Count(); i++)
                 {
                     RigidLink subLink = BH.Engine.Base.Query.ShallowClone(link);
-                    subLink.SlaveNodes = new List<Node> { link.SlaveNodes[i] };
+                    subLink.SecondaryNodes = new List<Node> { link.SecondaryNodes[i] };
                     if (link.Name != "")
                     {
                         subLink.Name = $"{link.Name}:::{i}";


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
/BHoM/BHoM/pull/961

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM/Structure_oM/Issue921-RigidLink%20property%20rename/Test%20Rigid%20Links%20-%20multi%20adapter.gh?csf=1&web=1&e=iDXtGs

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->