### PR TITLE
Fixes projected loading for distributed loading (uniform and varying) on bars

### DIFF
--- a/SAP2000_Adapter/CRUD/Create/Loads.cs
+++ b/SAP2000_Adapter/CRUD/Create/Loads.cs
@@ -176,7 +176,14 @@ namespace BH.Adapter.SAP2000
             switch (bhLoad.Axis)
             {
                 case LoadAxis.Global:
-                    dirs = new int[] { 4, 5, 6 };
+                    if (bhLoad.Projected)
+                    {
+                        dirs = new int[] { 7, 8, 9};
+                    }
+                    else
+                    {
+                        dirs = new int[] { 4, 5, 6 };
+                    }
                     forceVals = bhLoad.Force.ToDoubleArray();
                     momentVals = bhLoad.Moment.ToDoubleArray();
                     break;
@@ -227,7 +234,14 @@ namespace BH.Adapter.SAP2000
             switch (bhLoad.Axis)
             {
                 case LoadAxis.Global:
-                    dirs = new int[] { 4, 5, 6 };
+                    if (bhLoad.Projected)
+                    {
+                        dirs = new int[] { 7, 8, 9 };
+                    }
+                    else
+                    {
+                        dirs = new int[] { 4, 5, 6 };
+                    }
                     forceValsA = bhLoad.ForceAtStart.ToDoubleArray();
                     momentValsA = bhLoad.MomentAtStart.ToDoubleArray();
                     forceValsB = bhLoad.ForceAtEnd.ToDoubleArray();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Fixes #180 

<!-- Add short description of what has been fixed -->
Projected load direction flag added for varying bar load and uniform bar load.

### Test files
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/Installers/Scripts/BuroHappold_BHoM_v3.3/0027_Create%20Read%20Loads/BuroHappold_BHoM_v3.3.beta_Create%20read%20loads.gh?csf=1&web=1&e=fO9wtD


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->