### PR TITLE
Implemented FilterId for all Read methods

### DIFF
--- a/SAP2000_Adapter/CRUD/Read/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Read/Bar.cs
@@ -45,14 +45,11 @@ namespace BH.Adapter.SAP2000
             Dictionary<string, ISectionProperty> bhomSections = ReadSectionProperties().ToDictionary(x => GetAdapterId<string>(x));
 
             int nameCount = 0;
-            string[] names = { };
-            m_model.FrameObj.GetNameList(ref nameCount, ref names);
+            string[] nameArr = { };
+            m_model.FrameObj.GetNameList(ref nameCount, ref nameArr);
 
-            if (ids == null)
-            {
-                ids = names.ToList();
-            }
-            
+            ids = FilterIds(ids, nameArr);
+
             foreach (string id in ids)
             {
                 SAP2000Id sap2000id = new SAP2000Id();

--- a/SAP2000_Adapter/CRUD/Read/LinkConstraint.cs
+++ b/SAP2000_Adapter/CRUD/Read/LinkConstraint.cs
@@ -42,13 +42,11 @@ namespace BH.Adapter.SAP2000
         {
             List<LinkConstraint> propList = new List<LinkConstraint>();
 
-            if (ids == null)
-            {
-                int nameCount = 0;
-                string[] names = { };
-                m_model.PropLink.GetNameList(ref nameCount, ref names);
-                ids = names.ToList();
-            }
+            int nameCount = 0;
+            string[] nameArr = { };
+            m_model.PropLink.GetNameList(ref nameCount, ref nameArr);
+
+            ids = FilterIds(ids, nameArr); 
 
             foreach (string id in ids)
             {

--- a/SAP2000_Adapter/CRUD/Read/Material.cs
+++ b/SAP2000_Adapter/CRUD/Read/Material.cs
@@ -41,15 +41,12 @@ namespace BH.Adapter.SAP2000
             List<IMaterialFragment> materialList = new List<IMaterialFragment>();
 
             int nameCount = 0;
-            string[] names = { };
-            m_model.PropMaterial.GetNameList(ref nameCount, ref names);
+            string[] nameArr = { };
+            m_model.PropMaterial.GetNameList(ref nameCount, ref nameArr);
 
-            if (ids == null)
-            {
-                ids = names.ToList();
-            }
+            ids = FilterIds(ids, nameArr);
 
-            foreach (string materialName in ids)
+            foreach (string id in ids)
             {
                 eMatType matType = eMatType.NoDesign;
                 int symType = 0;
@@ -57,11 +54,11 @@ namespace BH.Adapter.SAP2000
                 string guid = "";
                 string notes = "";
 
-                if (m_model.PropMaterial.GetMaterial(materialName, ref matType, ref colour, ref notes, ref guid) == 0)
+                if (m_model.PropMaterial.GetMaterial(id, ref matType, ref colour, ref notes, ref guid) == 0)
                 {
                     IMaterialFragment bhMaterial;
 
-                    m_model.PropMaterial.GetTypeOAPI(materialName, ref matType, ref symType);
+                    m_model.PropMaterial.GetTypeOAPI(id, ref matType, ref symType);
 
                     double e = 0;
                     double v = 0;
@@ -75,25 +72,25 @@ namespace BH.Adapter.SAP2000
                     
                     if (symType == 0)// Isotropic
                     {
-                        m_model.PropMaterial.GetMPIsotropic(materialName, ref e, ref v, ref thermCo, ref g);
+                        m_model.PropMaterial.GetMPIsotropic(id, ref e, ref v, ref thermCo, ref g);
                     }
                     else if (symType == 1) // Orthotropic
                     {
-                        m_model.PropMaterial.GetMPOrthotropic(materialName, ref E, ref V, ref ThermCo, ref G);                        
+                        m_model.PropMaterial.GetMPOrthotropic(id, ref E, ref V, ref ThermCo, ref G);                        
                     }
                     else if (symType == 2) //Anisotropic
                     {
-                        m_model.PropMaterial.GetMPAnisotropic(materialName, ref E, ref V, ref ThermCo, ref G);
+                        m_model.PropMaterial.GetMPAnisotropic(id, ref E, ref V, ref ThermCo, ref G);
                     }
                     else if (symType == 3) //Uniaxial
                     {
-                        m_model.PropMaterial.GetMPUniaxial(materialName, ref e, ref thermCo);
+                        m_model.PropMaterial.GetMPUniaxial(id, ref e, ref thermCo);
                     }
 
                     double mass = 0;
                     double weight = 0;
 
-                    m_model.PropMaterial.GetWeightAndMass(materialName, ref weight, ref mass);
+                    m_model.PropMaterial.GetWeightAndMass(id, ref weight, ref mass);
 
                     double fc = 0;//compressive stress
                     double ft = 0;//tensile stress
@@ -113,52 +110,52 @@ namespace BH.Adapter.SAP2000
                     switch (matType)
                     {
                         case eMatType.Steel:
-                            m_model.PropMaterial.GetOSteel(materialName, ref fy, ref fu, ref efy, ref efu, ref i0, ref i1, ref strainHardening, ref strainMaxF, ref strainRupture);
-                            bhMaterial = Engine.Structure.Create.Steel(materialName, e, v, thermCo, mass, 0, fy, fu);
+                            m_model.PropMaterial.GetOSteel(id, ref fy, ref fu, ref efy, ref efu, ref i0, ref i1, ref strainHardening, ref strainMaxF, ref strainRupture);
+                            bhMaterial = Engine.Structure.Create.Steel(id, e, v, thermCo, mass, 0, fy, fu);
                             break;
                         case eMatType.Concrete:
-                            m_model.PropMaterial.GetOConcrete(materialName, ref fc, ref b0, ref ft, ref i0, ref i1, ref efy, ref efu, ref strainFc, ref strainMaxF);
-                            bhMaterial = Engine.Structure.Create.Concrete(materialName, e, v, thermCo, mass, 0, 0, fy);
+                            m_model.PropMaterial.GetOConcrete(id, ref fc, ref b0, ref ft, ref i0, ref i1, ref efy, ref efu, ref strainFc, ref strainMaxF);
+                            bhMaterial = Engine.Structure.Create.Concrete(id, e, v, thermCo, mass, 0, 0, fy);
                             break;
                         case eMatType.Aluminum:
-                            bhMaterial = Engine.Structure.Create.Aluminium(materialName, e, v, thermCo, mass, 0);
+                            bhMaterial = Engine.Structure.Create.Aluminium(id, e, v, thermCo, mass, 0);
                             break;
                         case eMatType.ColdFormed:
-                            m_model.PropMaterial.GetOColdFormed(materialName, ref fy, ref fu, ref i1);
-                            bhMaterial = Engine.Structure.Create.Steel(materialName, e, v, thermCo, mass, 0, fy, fu);
+                            m_model.PropMaterial.GetOColdFormed(id, ref fy, ref fu, ref i1);
+                            bhMaterial = Engine.Structure.Create.Steel(id, e, v, thermCo, mass, 0, fy, fu);
                             break;
                         case eMatType.Rebar:
-                            m_model.PropMaterial.GetORebar(materialName, ref fy, ref fu, ref efy, ref efu, ref i0, ref i1, ref strainHardening, ref strainMaxF, ref b0);
-                            bhMaterial = Engine.Structure.Create.Steel(materialName, e, v, thermCo, mass, 0, fy, fu);
+                            m_model.PropMaterial.GetORebar(id, ref fy, ref fu, ref efy, ref efu, ref i0, ref i1, ref strainHardening, ref strainMaxF, ref b0);
+                            bhMaterial = Engine.Structure.Create.Steel(id, e, v, thermCo, mass, 0, fy, fu);
                             break;
                         case eMatType.Tendon:
-                            m_model.PropMaterial.GetOTendon(materialName, ref fy, ref fu, ref i0, ref i1);
-                            bhMaterial = Engine.Structure.Create.Steel(materialName, e, v, thermCo, mass, 0, fy, fu);
+                            m_model.PropMaterial.GetOTendon(id, ref fy, ref fu, ref i0, ref i1);
+                            bhMaterial = Engine.Structure.Create.Steel(id, e, v, thermCo, mass, 0, fy, fu);
                             break;
                         case eMatType.NoDesign:
                             switch (symType)
                             {
                                 case 0: 
-                                    bhMaterial = new GenericIsotropicMaterial() { Name = materialName, YoungsModulus = e, PoissonsRatio = v, ThermalExpansionCoeff = thermCo, Density = mass };
+                                    bhMaterial = new GenericIsotropicMaterial() { Name = id, YoungsModulus = e, PoissonsRatio = v, ThermalExpansionCoeff = thermCo, Density = mass };
                                     break;
                                 case 1:
-                                    bhMaterial = new GenericOrthotropicMaterial() { Name = materialName, YoungsModulus = E.ToVector(), PoissonsRatio = V.ToVector(), ThermalExpansionCoeff = ThermCo.ToVector(), Density = mass };
+                                    bhMaterial = new GenericOrthotropicMaterial() { Name = id, YoungsModulus = E.ToVector(), PoissonsRatio = V.ToVector(), ThermalExpansionCoeff = ThermCo.ToVector(), Density = mass };
                                     break;
                                 case 2:
                                 case 3:
                                 default:
-                                    bhMaterial = Engine.Structure.Create.Steel(materialName);
-                                    Engine.Reflection.Compute.RecordWarning("Could not extract structural properties for material " + materialName);
+                                    bhMaterial = Engine.Structure.Create.Steel(id);
+                                    Engine.Reflection.Compute.RecordWarning("Could not extract structural properties for material " + id);
                                     break;
                             }
                             break;
                         default:
-                            bhMaterial = Engine.Structure.Create.Steel(materialName);
-                            Engine.Reflection.Compute.RecordWarning("Could not extract structural properties for material " + materialName);
+                            bhMaterial = Engine.Structure.Create.Steel(id);
+                            Engine.Reflection.Compute.RecordWarning("Could not extract structural properties for material " + id);
                             break;
                     }
 
-                    SetAdapterId(bhMaterial, materialName);
+                    SetAdapterId(bhMaterial, id);
 
                     materialList.Add(bhMaterial);
                 }

--- a/SAP2000_Adapter/CRUD/Read/Node.cs
+++ b/SAP2000_Adapter/CRUD/Read/Node.cs
@@ -46,13 +46,9 @@ namespace BH.Adapter.SAP2000
             int nameCount = 0;
             string[] nameArr = { };
 
-            if (ids == null)
-            {
-                if (m_model.PointObj.GetNameList(ref nameCount, ref nameArr) == 0)
-                {
-                    ids = nameArr.ToList();
-                }
-            }
+            m_model.PointObj.GetNameList(ref nameCount, ref nameArr);
+
+            ids = FilterIds(ids, nameArr);
 
             foreach (string id in ids)
             {

--- a/SAP2000_Adapter/CRUD/Read/Panel.cs
+++ b/SAP2000_Adapter/CRUD/Read/Panel.cs
@@ -45,14 +45,12 @@ namespace BH.Adapter.SAP2000
 
             Dictionary<string, Node> bhomNodes = ReadNodes().ToDictionary(x => GetAdapterId<string>(x));
             Dictionary<string, ISurfaceProperty> bhomProperties = ReadSurfaceProperty().ToDictionary(x => GetAdapterId<string>(x));
-            
-            if (ids == null)
-            {
-                int nameCount = 0;
-                string[] nameArr = { };
-                m_model.AreaObj.GetNameList(ref nameCount, ref nameArr);
-                ids = nameArr.ToList();
-            }
+                
+            int nameCount = 0;
+            string[] nameArr = { };
+            m_model.AreaObj.GetNameList(ref nameCount, ref nameArr);
+
+            ids = FilterIds(ids, nameArr);
 
             foreach (string id in ids)
             {

--- a/SAP2000_Adapter/CRUD/Read/RigidLink.cs
+++ b/SAP2000_Adapter/CRUD/Read/RigidLink.cs
@@ -44,25 +44,27 @@ namespace BH.Adapter.SAP2000
 
             //Read all links, filter by id at end, so that we can join multi-links.
             int nameCount = 0;
-            string[] names = { };
-            m_model.LinkObj.GetNameList(ref nameCount, ref names);
+            string[] nameArr = { };
+            m_model.LinkObj.GetNameList(ref nameCount, ref nameArr);
+
+            ids = FilterIds(ids, nameArr);
             
-            foreach (string name in names)
+            foreach (string id in ids)
             {
                 RigidLink newLink = new RigidLink();
                 SAP2000Id sap2000id = new SAP2000Id();
                 string guid = null;
 
-                sap2000id.Id = name;
+                sap2000id.Id = id;
 
                 string primaryId = "";
                 string secondaryId = "";
                 string propName = "";
-                m_model.LinkObj.GetPoints(name, ref primaryId, ref secondaryId);
+                m_model.LinkObj.GetPoints(id, ref primaryId, ref secondaryId);
                 newLink.PrimaryNode = bhomNodes[primaryId];
                 newLink.SecondaryNodes = new List<Node> { bhomNodes[secondaryId] };
 
-                m_model.LinkObj.GetProperty(name, ref propName);
+                m_model.LinkObj.GetProperty(id, ref propName);
                 LinkConstraint bhProp = new LinkConstraint();
                 bhomLinkConstraints.TryGetValue(propName, out bhProp);
                 newLink.Constraint = bhProp;
@@ -70,13 +72,13 @@ namespace BH.Adapter.SAP2000
                 // Get the groups the link is assigned to
                 int numGroups = 0;
                 string[] groupNames = new string[0];
-                if (m_model.LinkObj.GetGroupAssign(name, ref numGroups, ref groupNames) == 0)
+                if (m_model.LinkObj.GetGroupAssign(id, ref numGroups, ref groupNames) == 0)
                 {
                     foreach (string grpName in groupNames)
                         newLink.Tags.Add(grpName);
                 }
 
-                if (m_model.LinkObj.GetGUID(name, ref guid) == 0)
+                if (m_model.LinkObj.GetGUID(id, ref guid) == 0)
                     sap2000id.PersistentId = guid;
 
                 newLink.SetAdapterId(sap2000id);

--- a/SAP2000_Adapter/CRUD/Read/Section.cs
+++ b/SAP2000_Adapter/CRUD/Read/Section.cs
@@ -47,14 +47,11 @@ namespace BH.Adapter.SAP2000
             Dictionary<string, IMaterialFragment> bhomMaterials = ReadMaterial().ToDictionary(x => GetAdapterId<string>(x));
 
             int nameCount = 0;
-            string[] names = { };
-            m_model.PropFrame.GetNameList(ref nameCount, ref names);
+            string[] nameArr = { };
+            m_model.PropFrame.GetNameList(ref nameCount, ref nameArr);
 
-            if (ids == null)
-            {
-                ids = names.ToList();
-            }
-            
+            ids = FilterIds(ids, nameArr);
+
             foreach (string id in ids)
             {
                 eFramePropType propertyType = eFramePropType.General;

--- a/SAP2000_Adapter/CRUD/Read/SurfaceProperty.cs
+++ b/SAP2000_Adapter/CRUD/Read/SurfaceProperty.cs
@@ -45,12 +45,9 @@ namespace BH.Adapter.SAP2000
 
             int nameCount = 0;
             string[] nameArr = { };
+            m_model.PropArea.GetNameList(ref nameCount, ref nameArr);
 
-            if (ids == null)
-            {
-                m_model.PropArea.GetNameList(ref nameCount, ref nameArr);
-                ids = nameArr.ToList();
-            }
+            ids = FilterIds(ids, nameArr);
 
             foreach (string id in ids)
             {

--- a/SAP2000_Adapter/CRUD/Read/_IRead.cs
+++ b/SAP2000_Adapter/CRUD/Read/_IRead.cs
@@ -35,6 +35,7 @@ using BH.oM.Adapter;
 using BH.oM.Analytical.Results;
 using BH.oM.Structure.Results;
 using BH.oM.Structure.Requests;
+using System.ComponentModel;
 
 namespace BH.Adapter.SAP2000
 {
@@ -43,31 +44,36 @@ namespace BH.Adapter.SAP2000
         /***************************************************/
         /**** Adapter overload method                   ****/
         /***************************************************/
-        
+
         protected override IEnumerable<IBHoMObject> IRead(Type type, IList ids, ActionConfig actionConfig = null)
         {
+
+            List<string> listIds = null;
+            if (ids != null && ids.Count != 0)
+                listIds = ids.Cast<string>().ToList();
+
             if (type == typeof(Node))
-                return ReadNodes(ids as dynamic);
+                return ReadNodes(listIds);
             else if (type == typeof(Bar))
-                return ReadBars(ids as dynamic);
+                return ReadBars(listIds);
             else if (type == typeof(ISectionProperty) || type.GetInterfaces().Contains(typeof(ISectionProperty)))
-                return ReadSectionProperties(ids as dynamic);
+                return ReadSectionProperties(listIds);
             else if (type == typeof(IMaterialFragment) || type.GetInterfaces().Contains(typeof(IMaterialFragment)))
-                return ReadMaterial(ids as dynamic);
+                return ReadMaterial(listIds);
             else if (type == typeof(Panel))
-                return ReadPanel(ids as dynamic);
+                return ReadPanel(listIds);
             else if (type == typeof(ISurfaceProperty) || type.GetInterfaces().Contains(typeof(ISurfaceProperty)))
-                return ReadSurfaceProperty(ids as dynamic);
+                return ReadSurfaceProperty(listIds);
             else if (type == typeof(LoadCombination))
-                return ReadLoadCombination(ids as dynamic);
+                return ReadLoadCombination(listIds);
             else if (type == typeof(Loadcase))
-                return ReadLoadcase(ids as dynamic);
+                return ReadLoadcase(listIds);
             else if (type == typeof(ILoad) || type.GetInterfaces().Contains(typeof(ILoad)))
-                return ReadLoad(type, ids as dynamic);
+                return ReadLoad(type, listIds);
             else if (type == typeof(RigidLink))
-                return ReadRigidLink(ids as dynamic);
+                return ReadRigidLink(listIds);
             else if (type == typeof(LinkConstraint))
-                return ReadLinkConstraints(ids as dynamic);
+                return ReadLinkConstraints(listIds);
             else if (typeof(IResult).IsAssignableFrom(type))
             {
                 Modules.Structure.ErrorMessages.ReadResultsError(type);
@@ -75,10 +81,28 @@ namespace BH.Adapter.SAP2000
             }
 
 
-            return null;
-        }
+            return new List<IBHoMObject>();
 
-        /***************************************************/
+        }
+            /***************************************************/
+
+            [Description("Ensures that all elements in the first list are present in the second list, warning if not, and returns the second list if the first list is empty.")]
+            private static List<string> FilterIds(IEnumerable<string> ids, IEnumerable<string> sapIds)
+            {
+                if (ids == null || ids.Count() == 0)
+                {
+                    return sapIds.ToList();
+                }
+                else
+                {
+                    List<string> result = ids.Intersect(sapIds).ToList();
+                    if (result.Count() != ids.Count())
+                        Engine.Reflection.Compute.RecordWarning("Some requested SAP2000 ids were not present in the model.");
+                    return result;
+                }
+            }
+
+            /***************************************************/
+        }
     }
-}
 

--- a/SAP2000_Adapter/CRUD/Read/_IRead.cs
+++ b/SAP2000_Adapter/CRUD/Read/_IRead.cs
@@ -36,6 +36,7 @@ using BH.oM.Analytical.Results;
 using BH.oM.Structure.Results;
 using BH.oM.Structure.Requests;
 using System.ComponentModel;
+using BH.oM.Data.Requests;
 
 namespace BH.Adapter.SAP2000
 {
@@ -84,25 +85,83 @@ namespace BH.Adapter.SAP2000
             return new List<IBHoMObject>();
 
         }
-            /***************************************************/
+        /***************************************************/
 
-            [Description("Ensures that all elements in the first list are present in the second list, warning if not, and returns the second list if the first list is empty.")]
-            private static List<string> FilterIds(IEnumerable<string> ids, IEnumerable<string> sapIds)
+        public IEnumerable<IBHoMObject> Read(SelectionRequest request, ActionConfig actionConfig = null)
+        {
+            List<IBHoMObject> results = new List<IBHoMObject>();
+
+            foreach (KeyValuePair<Type, List<string>> keyVal in SelectedElements())
             {
-                if (ids == null || ids.Count() == 0)
-                {
-                    return sapIds.ToList();
-                }
-                else
-                {
-                    List<string> result = ids.Intersect(sapIds).ToList();
-                    if (result.Count() != ids.Count())
-                        Engine.Reflection.Compute.RecordWarning("Some requested SAP2000 ids were not present in the model.");
-                    return result;
-                }
+                results.AddRange(IRead(keyVal.Key, keyVal.Value, actionConfig));
             }
 
-            /***************************************************/
+            return results;
         }
+
+        /***************************************************/
+
+        public Dictionary<Type, List<string>> SelectedElements()
+        {
+            int numItems = 0;
+            int[] objectTypes = new int[0];
+            string[] objectIds = new string[0];
+
+            m_model.SelectObj.GetSelected(ref numItems, ref objectTypes, ref objectIds);
+
+            Dictionary<int, List<string>> dict = objectTypes.Distinct().ToDictionary(x => x, x => new List<string>());
+
+            for (int i = 0; i < numItems; i++)
+            {
+                dict[objectTypes[i]].Add(objectIds[i]);
+            }
+
+            Func<int, Type> ToType = x =>
+            {
+                switch (x)
+                {
+                    case 1:
+                        return typeof(Node);
+                    case 2:
+                    case 3:
+                    case 4:
+                        return typeof(Bar);
+                    case 5:
+                        return typeof(Panel);
+                    case 6:
+                        return null;
+                    case 7:
+                        return typeof(RigidLink);
+                    default:
+                        return null; 
+
+
+                }
+            };
+
+            return dict.ToDictionary(x => ToType(x.Key), x => x.Value);
+            
+
+        }
+        /***************************************************/
+
+        [Description("Ensures that all elements in the first list are present in the second list, warning if not, and returns the second list if the first list is empty.")]
+        private static List<string> FilterIds(IEnumerable<string> ids, IEnumerable<string> sapIds)
+        {
+            if (ids == null || ids.Count() == 0)
+            {
+                return sapIds.ToList();
+            }
+            else
+            {
+                List<string> result = ids.Intersect(sapIds).ToList();
+                if (result.Count() != ids.Count())
+                    Engine.Reflection.Compute.RecordWarning("Some requested SAP2000 ids were not present in the model.");
+                return result;
+            }
+        }
+
+        /***************************************************/
     }
+}
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #111 
Closes #127 

All SAP elements that can be read can now be filtered if the SAP object ID is known.
Active selection in SAP can be pulled into the BHoM.


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/SAP2000_Toolkit/%23111-FilterRequestByObjectId?csf=1&web=1&e=8k6Jc2

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->