### PR TITLE
Align to BHoM_Adapter's AdapterId() method change

### DIFF
--- a/SAP2000_Adapter/CRUD/Update/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Update/Bar.cs
@@ -44,15 +44,14 @@ namespace BH.Adapter.SAP2000
 
             foreach (Bar bhBar in bhBars)
             {
-                object id = bhBar.AdapterId<string>(typeof(SAP2000Id));
+                string id = bhBar.AdapterId<string>(typeof(SAP2000Id));
                 if (id == null)
                 {
                     Engine.Reflection.Compute.RecordWarning("The Bar must have a SAP2000 adapter id to be updated.");
                     continue;
                 }
 
-                string name = id as string;
-                if (!nameArr.Contains(name))
+                if (!nameArr.Contains(id))
                 {
                     Engine.Reflection.Compute.RecordWarning("The Bar must be present in SAP2000 to be updated");
                     continue;
@@ -70,7 +69,7 @@ namespace BH.Adapter.SAP2000
                 string sapBarI = "";
                 string sapBarJ = "";
 
-                if (m_model.FrameObj.GetPoints(name, ref sapBarI, ref sapBarJ) != 0)
+                if (m_model.FrameObj.GetPoints(id, ref sapBarI, ref sapBarJ) != 0)
                 {
                     Engine.Reflection.Compute.RecordError($"Bar {bhBar.Name} failed to update because its nodes were not found in SAP2000. Check that geometry is valid.");
                     return false;

--- a/SAP2000_Adapter/CRUD/Update/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Update/Bar.cs
@@ -44,7 +44,7 @@ namespace BH.Adapter.SAP2000
 
             foreach (Bar bhBar in bhBars)
             {
-                object id = bhBar.AdapterId(typeof(SAP2000Id));
+                object id = bhBar.AdapterId<string>(typeof(SAP2000Id));
                 if (id == null)
                 {
                     Engine.Reflection.Compute.RecordWarning("The Bar must have a SAP2000 adapter id to be updated.");


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Adapter/pull/287
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes https://github.com/BHoM/SAP2000_Toolkit/issues/199

<!-- Add short description of what has been fixed -->
The SAP2000 adapter was relying on the non-generic `AdapterId()` method to get the Id of the objects. While this is not wrong per se, that method has now been renamed to `AdapterIds()` (note the s) to highlight the fact that it may return _more than only one Id, depending on whether multiple Ids have been stored on the object_.  
As this adapter currently does not need to use that feature, this PR simply replaces it with calls to `AdapterId<T>()`.

### Test files
<!-- Link to test files to validate the proposed changes -->
Testing of existing functionality is needed to make sure that everything works as before.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->