### PR TITLE
Add load ids to fix Create Load issue

### DIFF
--- a/SAP2000_Adapter/CRUD/Create/Loads.cs
+++ b/SAP2000_Adapter/CRUD/Create/Loads.cs
@@ -127,6 +127,8 @@ namespace BH.Adapter.SAP2000
                 }
             }
 
+            SetAdapterId(bhLoad, null);
+
             return true;
         }
 
@@ -157,6 +159,8 @@ namespace BH.Adapter.SAP2000
                     CreateElementError("Point Displacement", bhLoad.Name);
                 }
             }
+
+            SetAdapterId(bhLoad, null);
 
             return true;
         }
@@ -212,6 +216,8 @@ namespace BH.Adapter.SAP2000
                         CreateElementError("BarLoad", bhBar.Name + dirs[i]);
                 }
             }
+
+            SetAdapterId(bhLoad, null);
 
             return true;
         }
@@ -275,6 +281,8 @@ namespace BH.Adapter.SAP2000
                         CreateElementError("BarLoad", bhBar.Name + dirs[i]);
                 }
             }
+
+            SetAdapterId(bhLoad, null);
 
             return true;
         }
@@ -341,6 +349,8 @@ namespace BH.Adapter.SAP2000
                 }
             }
 
+            SetAdapterId(bhLoad, null);
+
             return true;
         }
 
@@ -362,8 +372,10 @@ namespace BH.Adapter.SAP2000
                 {
                     CreateElementError("AreaUniformTemperatureLoad", bhLoad.Name);
                 }
-                
+
             }
+
+            SetAdapterId(bhLoad, null);
 
             Engine.Reflection.Compute.RecordNote("SAP2000 includes functionality for temperature gradient application, but that feature is not yet supported here.");
 
@@ -385,6 +397,8 @@ namespace BH.Adapter.SAP2000
             AreaUniformlyDistributedLoad contourLoadArea = Engine.Structure.Create.AreaUniformlyDistributedLoad(bhLoad.Loadcase, loadVals.ToVector(), panelsToLoad, 
                                                                                                                 bhLoad.Axis, bhLoad.Projected, bhLoad.Name);
             CreateLoad(contourLoadArea);
+
+            SetAdapterId(bhLoad, null);
 
             return true;
         }
@@ -414,29 +428,33 @@ namespace BH.Adapter.SAP2000
                                                                                                         distanceFromB, forceB, momentB, false, bhLoad.Axis, bhLoad.Projected, bhLoad.Name);
             CreateLoad(barVaryLoad);
 
+            SetAdapterId(bhLoad, null);
+
             return true;
         }
 
         /***************************************************/
 
-        private bool CreateLoad(GravityLoad gravityLoad)
+        private bool CreateLoad(GravityLoad bhLoad)
         {
             double selfWeightExisting = 0;
-            double selfWeightNew = -gravityLoad.GravityDirection.Z;
+            double selfWeightNew = -bhLoad.GravityDirection.Z;
 
-            string caseName = GetAdapterId<string>(gravityLoad.Loadcase);
+            string caseName = GetAdapterId<string>(bhLoad.Loadcase);
 
             m_model.LoadPatterns.GetSelfWTMultiplier(caseName, ref selfWeightExisting);
 
             if (selfWeightExisting != 0)
-                BH.Engine.Reflection.Compute.RecordWarning($"The self weight for loadcase {gravityLoad.Loadcase.Name} will be overwritten. Previous value: {selfWeightExisting}, new value: {selfWeightNew}");
+                BH.Engine.Reflection.Compute.RecordWarning($"The self weight for loadcase {bhLoad.Loadcase.Name} will be overwritten. Previous value: {selfWeightExisting}, new value: {selfWeightNew}");
 
             m_model.LoadPatterns.SetSelfWTMultiplier(caseName, selfWeightNew);
 
-            if (gravityLoad.GravityDirection.X != 0 || gravityLoad.GravityDirection.Y != 0)
+            if (bhLoad.GravityDirection.X != 0 || bhLoad.GravityDirection.Y != 0)
                 Engine.Reflection.Compute.RecordError("SAP2000 can only handle gravity loads in global z direction");
 
             BH.Engine.Reflection.Compute.RecordNote("SAP2000 handles gravity loads via loadcases, so only one gravity load per loadcase can be used. This gravity load will be applied to all objects.");
+
+            SetAdapterId(bhLoad, null);
 
             return true;
         }
@@ -459,6 +477,8 @@ namespace BH.Adapter.SAP2000
             }
 
             Engine.Reflection.Compute.RecordNote("SAP2000 includes functionality for temperature gradient in 2 and 3 local bar axes, but the BHoM currently only supports uniform temperature changes.");
+
+            SetAdapterId(bhLoad, null);
 
             return true;
         }
@@ -515,6 +535,8 @@ namespace BH.Adapter.SAP2000
 
             }
 
+            SetAdapterId(bhLoad, null);
+
             return true;
         }
 
@@ -543,6 +565,8 @@ namespace BH.Adapter.SAP2000
                     CreateElementError("BarPrestressLoad", bar.Name);
                 BH.Engine.Reflection.Compute.RecordWarning($"Target Force load case must be nonlinear static. Verify {loadPat} prior to running analysis.");
             }
+
+            SetAdapterId(bhLoad, null);
 
             return true;
         }


### PR DESCRIPTION
BHoM adapter requires pushed objects to have AdapterIds, but SAP doesn't use ids for (most) loads, so this provides a null.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #198 

<!-- Add short description of what has been fixed -->
return null AdapterIds so that BHoM Adapter doesn't crash.

SAP uses a GUID for some (but not all) of it's loads, and has separate API calls to use them. This may be useful in order to update loads at a future date, but is not necessary for normal functionality.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/SAP2000_Toolkit/%23198-Load-Cases-will-not-push-all-at-once?csf=1&web=1&e=yeim11

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->