### PR TITLE
BarResult divisions fixed and modest speed improvements

### DIFF
--- a/SAP2000_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/BarResults.cs
@@ -247,11 +247,13 @@ namespace BH.Adapter.SAP2000
         {
             string p1Id = "";
             string p2Id = "";
+            Point p1;
+            Point p2;
 
             m_model.FrameObj.GetPoints(barId, ref p1Id, ref p2Id);
 
-            if (pts.TryGetValue(p1Id, out Point p1) &&
-                pts.TryGetValue(p2Id, out Point p2))
+            if (pts.TryGetValue(p1Id, out p1) &&
+                pts.TryGetValue(p2Id, out p2))
             {
                 return p1.Distance(p2);
             }

--- a/SAP2000_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/BarResults.cs
@@ -166,6 +166,8 @@ namespace BH.Adapter.SAP2000
                                                     "'Divisions' parameter will not be considered in result extraction");
             }
 
+            m_model.SelectObj.All();
+
             int resultCount = 0;
             string[] loadcaseNames = null;
             string[] objects = null;
@@ -175,11 +177,6 @@ namespace BH.Adapter.SAP2000
             double[] stepNum = null;
             string[] stepType = null;
 
-            int div = 0;
-            string[] intElems = null;
-            double[] di = null;
-            double[] dj = null;
-
             double[] p = null;
             double[] v2 = null;
             double[] v3 = null;
@@ -187,43 +184,32 @@ namespace BH.Adapter.SAP2000
             double[] m2 = null;
             double[] m3 = null;
 
-            Dictionary<string, Point> points = new Dictionary<string, Point>();
-
-            for (int i = 0; i < barIds.Count; i++)
+            if (m_model.Results.FrameForce(barIds[0], //this is ignored if type is SelectionElm
+                                                    eItemTypeElm.SelectionElm,
+                                                    ref resultCount,
+                                                    ref objects,
+                                                    ref objStation,
+                                                    ref elm,
+                                                    ref elmStation,
+                                                    ref loadcaseNames,
+                                                    ref stepType,
+                                                    ref stepNum,
+                                                    ref p,
+                                                    ref v2,
+                                                    ref v3,
+                                                    ref t,
+                                                    ref m2,
+                                                    ref m3) != 0)
             {
-                //Get element length
-                double length = GetBarLength(barIds[i], points);
-
-                //get number of divisions
-                m_model.FrameObj.GetElm(barIds[i], ref div, ref intElems, ref di, ref dj);
-                divisions = div + 1;
-
-                if (m_model.Results.FrameForce(barIds[i],
-                                                     eItemTypeElm.ObjectElm,
-                                                     ref resultCount,
-                                                     ref objects,
-                                                     ref objStation,
-                                                     ref elm,
-                                                     ref elmStation,
-                                                     ref loadcaseNames,
-                                                     ref stepType,
-                                                     ref stepNum,
-                                                     ref p,
-                                                     ref v2,
-                                                     ref v3,
-                                                     ref t,
-                                                     ref m2,
-                                                     ref m3) != 0)
+                Engine.Reflection.Compute.RecordError($"Could not extract results.");
+            }
+            else
+            {
+                //get lengths and divisions
+                for (int j = 0; j < resultCount; j++)
                 {
-                    Engine.Reflection.Compute.RecordError($"Could not extract results for an output station in bar {barIds}.");
-                }
-                else
-                {
-                    for (int j = 0; j < resultCount; j++)
-                    {
-                        BarForce bf = new BarForce(barIds[i], loadcaseNames[j], -1, stepNum[j], objStation[j] / length, divisions, p[j], v3[j], v2[j], t[j], -m3[j], m2[j]);
-                        barForces.Add(bf);
-                    }
+                    BarForce bf = new BarForce(objects[j], loadcaseNames[j], -1, stepNum[j], objStation[j], divisions, p[j], v3[j], v2[j], t[j], -m3[j], m2[j]);
+                    barForces.Add(bf);
                 }
             }
 
@@ -268,6 +254,8 @@ namespace BH.Adapter.SAP2000
                     barIds.Add(ids[i].ToString());
                 }
             }
+
+
 
             return barIds;
         }

--- a/SAP2000_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -180,27 +180,7 @@ namespace BH.Adapter.SAP2000
         /**** Private method - Support methods          ****/
         /***************************************************/
 
-        private List<string> CheckGetNodeIds(NodeResultRequest request)
-        {
-            List<string> nodeIds = new List<string>();
-            var ids = request.ObjectIds;
 
-            if (ids == null || ids.Count == 0)
-            {
-                int nodes = 0;
-                string[] names = null;
-                m_model.PointObj.GetNameList(ref nodes, ref names);
-                nodeIds = names.ToList();
-            }
-            else
-            {
-                for (int i = 0; i < ids.Count; i++)
-                {
-                    nodeIds.Add(ids[i].ToString());
-                }
-            }
-            return nodeIds;
-        }
     }
 }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #171 

<!-- Add short description of what has been fixed -->
SAP does not allow specifying how many output stations to pull, so the Pull will now return a note to that effect, and the results output will show the number of divisions returned.

Also, a few bits of code were streamlined, hopefully resulting in modest performance enhancements. 

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/SAP2000_Toolkit/%23171-BarResultRequest%20divisions%20not%20working/Pull%20Structural%20Analysis%20Results.gh?csf=1&web=1&e=4H30H3

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->