### PR TITLE
Add UpdateOnlyBarAssigns to allow quick property assignment updates.

### DIFF
--- a/SAP2000_Adapter/CRUD/Create/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Create/Bar.cs
@@ -81,17 +81,6 @@ namespace BH.Adapter.SAP2000
             bhBar.SetAdapterId(sap2000IdFragment);
 
             // Set Properties
-            SetObject(bhBar);
-
-            return true;
-        }
-
-        /***************************************************/
-        [Description("Does all the SAP2000 interaction which does not initiate a new object in SAP2000.")]
-        private bool SetObject(Bar bhBar)
-        {
-            string name = GetAdapterId<string>(bhBar);
-
             SetSectionProperty(bhBar, name);
             SetOrientationAngle(bhBar, name);
             SetRelease(bhBar, name);
@@ -103,6 +92,24 @@ namespace BH.Adapter.SAP2000
 
             return true;
         }
+
+        /***************************************************/
+        //[Description("Does all the SAP2000 interaction which does not initiate a new object in SAP2000.")]
+        //private bool SetObject(Bar bhBar)
+        //{
+        //    string name = GetAdapterId<string>(bhBar);
+
+        //    SetSectionProperty(bhBar, name);
+        //    SetOrientationAngle(bhBar, name);
+        //    SetRelease(bhBar, name);
+        //    SetOffsets(bhBar, name);
+        //    SetGroups(bhBar, name);
+        //    SetAutomesh(bhBar, name);
+        //    SetDesignProcedure(bhBar, name);
+        //    SetInsertionPoint(bhBar, name);
+
+        //    return true;
+        //}
 
         private void SetSectionProperty(Bar bhBar, string name)
         {

--- a/SAP2000_Adapter/CRUD/Create/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Create/Bar.cs
@@ -92,6 +92,20 @@ namespace BH.Adapter.SAP2000
         {
             string name = GetAdapterId<string>(bhBar);
 
+            SetSectionProperty(bhBar, name);
+            SetOrientationAngle(bhBar, name);
+            SetRelease(bhBar, name);
+            SetOffsets(bhBar, name);
+            SetGroups(bhBar, name);
+            SetAutomesh(bhBar, name);
+            SetDesignProcedure(bhBar, name);
+            SetInsertionPoint(bhBar, name);
+
+            return true;
+        }
+
+        private void SetSectionProperty(Bar bhBar, string name)
+        {
             if (bhBar.SectionProperty != null)
             {
                 string propId = GetAdapterId<string>(bhBar.SectionProperty);
@@ -103,7 +117,9 @@ namespace BH.Adapter.SAP2000
                     }
                 }
             }
-
+        }
+        private void SetOrientationAngle(Bar bhBar, string name)
+        {
             if (bhBar.OrientationAngle != 0)
             {
                 if (m_model.FrameObj.SetLocalAxes(name, bhBar.OrientationAngle * 180 / System.Math.PI) != 0)
@@ -111,7 +127,9 @@ namespace BH.Adapter.SAP2000
                     CreatePropertyWarning("Orientation angle", "Bar", name);
                 }
             }
-
+        }
+        private void SetRelease(Bar bhBar, string name)
+        {
             if (bhBar.Release != null)
             {
                 bool[] restraintStart = null;
@@ -128,10 +146,9 @@ namespace BH.Adapter.SAP2000
                 }
 
             }
-
-
-            // Bar End Length Offset
-
+        }
+        private void SetOffsets(Bar bhBar, string name)
+        {
             if (bhBar.Offset != null)
             {
                 if (bhBar.Offset.Start != null && bhBar.Offset.End != null)
@@ -142,7 +159,9 @@ namespace BH.Adapter.SAP2000
                     }
                 }
             }
-
+        }
+        private void SetGroups(Bar bhBar, string name)
+        {
             foreach (string gName in bhBar.Tags)
             {
                 string groupName = gName.ToString();
@@ -152,14 +171,9 @@ namespace BH.Adapter.SAP2000
                     m_model.FrameObj.SetGroupAssign(name, groupName);
                 }
             }
-
-            /***************************************************/
-            /* SAP Fragments                                   */
-            /***************************************************/
-
-
-            // Automesh
-
+        }
+        private void SetAutomesh(Bar bhBar, string name)
+        {
             BarAutoMesh barAutoMesh = bhBar.BarAutoMesh();
 
             if (barAutoMesh != null)
@@ -175,9 +189,9 @@ namespace BH.Adapter.SAP2000
                     CreatePropertyWarning("AutoMesh", "Bar", name);
                 }
             }
-
-            // Design Procedure
-
+        }
+        private void SetDesignProcedure(Bar bhBar, string name)
+        {
             BarDesignProcedure barDesignProcedure = bhBar.BarDesignProcedure();
 
             if (barDesignProcedure != null)
@@ -209,38 +223,36 @@ namespace BH.Adapter.SAP2000
                     {
                         Engine.Reflection.Compute.RecordNote($"Bar {bhBar.Name} with SAP id {name} does not have a design procedure.");
                     }
-
                 }
             }
 
-            // Insertion Point Offset
+        }
+        private void SetInsertionPoint(Bar bhBar, string name)
+        {
+                Offset offset = bhBar.Offset;
 
-            Offset offset = bhBar.Offset;
+                double[] offset1 = new double[3];
+                double[] offset2 = new double[3];
 
-            double[] offset1 = new double[3];
-            double[] offset2 = new double[3];
-
-            if (offset != null)
-            {
-                if (offset.Start != null)
+                if (offset != null)
                 {
-                    offset1[1] = offset.Start.Z;
-                    offset1[2] = offset.Start.Y;
+                    if (offset.Start != null)
+                    {
+                        offset1[1] = offset.Start.Z;
+                        offset1[2] = offset.Start.Y;
+                    }
+
+                    if (offset.End != null)
+                    {
+                        offset2[1] = offset.End.Z;
+                        offset2[2] = offset.End.Y;
+                    }
                 }
 
-                if (offset.End != null)
+                if (m_model.FrameObj.SetInsertionPoint(name, (int)bhBar.BarInsertionPoint(), false, bhBar.BarModifyStiffnessInsertionPoint(), ref offset1, ref offset2) != 0)
                 {
-                    offset2[1] = offset.End.Z;
-                    offset2[2] = offset.End.Y;
+                    CreatePropertyWarning("Insertion point and perpendicular offset", "Bar", name);
                 }
-            }
-
-            if (m_model.FrameObj.SetInsertionPoint(name, (int)bhBar.BarInsertionPoint(), false, bhBar.BarModifyStiffnessInsertionPoint(), ref offset1, ref offset2) != 0)
-            {
-                CreatePropertyWarning("Insertion point and perpendicular offset", "Bar", name);
-            }
-            
-            return true;
         }
     }
 }

--- a/SAP2000_Adapter/CRUD/Update/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Update/Bar.cs
@@ -83,6 +83,10 @@ namespace BH.Adapter.SAP2000
                     UpdateObjects(barNodes);
                 }
                 SetObject(bhBar);
+                // Conditional checking for whether to update a property -- only if it has changed
+                // How can I access the old bhom object vs the new bhom object?
+                //Engine.Structure.NameOrDescriptionComparer comparer = AdapterComparers[typeof(Bar)] as Engine.Structure.NameOrDescriptionComparer;
+
             }
             return success;
         }

--- a/SAP2000_Adapter/CRUD/Update/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Update/Bar.cs
@@ -82,10 +82,48 @@ namespace BH.Adapter.SAP2000
                     List<Node> barNodes = new List<Node>() { bhBar.StartNode, bhBar.EndNode };
                     UpdateObjects(barNodes);
                 }
-                SetObject(bhBar);
-                // Conditional checking for whether to update a property -- only if it has changed
-                // How can I access the old bhom object vs the new bhom object?
-                //Engine.Structure.NameOrDescriptionComparer comparer = AdapterComparers[typeof(Bar)] as Engine.Structure.NameOrDescriptionComparer;
+
+                // Set Properties
+                SetSectionProperty(bhBar, name);
+                SetOrientationAngle(bhBar, name);
+                SetRelease(bhBar, name);
+                SetOffsets(bhBar, name);
+                SetGroups(bhBar, name);
+                SetAutomesh(bhBar, name);
+                SetDesignProcedure(bhBar, name);
+                SetInsertionPoint(bhBar, name);
+
+            }
+            return success;
+        }
+
+        private bool UpdateBarPropAssigns(IEnumerable<Bar> bhBars)
+        {
+            bool success = true;
+            m_model.SelectObj.ClearSelection();
+
+            int nameCount = 0;
+            string[] nameArr = { };
+            m_model.FrameObj.GetNameList(ref nameCount, ref nameArr);
+
+            foreach (Bar bhBar in bhBars)
+            {
+                object id = bhBar.AdapterId(typeof(SAP2000Id));
+                if (id == null)
+                {
+                    Engine.Reflection.Compute.RecordWarning("The Bar must have a SAP2000 adapter id to be updated.");
+                    continue;
+                }
+
+                string name = id as string;
+                if (!nameArr.Contains(name))
+                {
+                    Engine.Reflection.Compute.RecordWarning("The Bar must be present in SAP2000 to be updated");
+                    continue;
+                }
+
+                // Set Properties
+                SetSectionProperty(bhBar, name);
 
             }
             return success;

--- a/SAP2000_Adapter/CRUD/Update/Section.cs
+++ b/SAP2000_Adapter/CRUD/Update/Section.cs
@@ -50,8 +50,8 @@ namespace BH.Adapter.SAP2000
                     Engine.Reflection.Compute.RecordWarning($"Failed to update SectionProperty: { propertyName }, no section with that name found in SAP2000.");
                     continue;
                 }
-                string matName = "Default";
-                matName = bhomSection.Material.DescriptionOrName();
+
+                string matName = bhomSection.Material.DescriptionOrName();
                 SetSection(bhomSection as dynamic, matName);
                 SetModifiers(bhomSection);
             }

--- a/SAP2000_Adapter/CRUD/Update/_IUpdate.cs
+++ b/SAP2000_Adapter/CRUD/Update/_IUpdate.cs
@@ -23,6 +23,10 @@
 using BH.oM.Adapter;
 using BH.oM.Base;
 using System.Collections.Generic;
+using BH.oM.Adapters.SAP2000;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.SectionProperties;
+using System.Linq;
 
 namespace BH.Adapter.SAP2000
 {
@@ -34,7 +38,16 @@ namespace BH.Adapter.SAP2000
 
         protected override bool IUpdate<T>(IEnumerable<T> objects, ActionConfig actionConfig = null)
         {
-            return UpdateObjects(objects as dynamic);
+            SAP2000PushConfig config = (SAP2000PushConfig)actionConfig;
+
+            if (config != null && config.UpdateOnlyBarPropAssigns) // Only update bar assigns
+            {
+                return UpdateBarPropAssigns(objects.OfType<Bar>());
+            }
+            else
+            {
+                return UpdateObjects(objects as dynamic);
+            }
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/SAP2000Adapter.cs
+++ b/SAP2000_Adapter/SAP2000Adapter.cs
@@ -34,7 +34,7 @@ namespace BH.Adapter.SAP2000
         /**** Public Properties                         ****/
         /***************************************************/
         
-            public SAP2000ActionConfig SAPConfig { get; set; } = new SAP2000ActionConfig();
+            public SAP2000PushConfig SAPConfig { get; set; } = new SAP2000PushConfig();
 
         /***************************************************/
         /**** Constructors                              ****/

--- a/SAP2000_oM/Config/SAP2000PushConfig.cs
+++ b/SAP2000_oM/Config/SAP2000PushConfig.cs
@@ -29,7 +29,7 @@ namespace BH.oM.Adapters.SAP2000
     [Description("This Config can be specified in the `ActionConfig` input of any Adapter Action (e.g. Push).")]
     // Note: this will get passed within any CRUD method (see their signature). 
     // In order to access its properties, you will need to cast it to `SAP2000ActionConfig`.
-    public class SAP2000ActionConfig : ActionConfig
+    public class SAP2000PushConfig : ActionConfig
     {
         /***************************************************/
         /**** Public Properties                         ****/
@@ -37,6 +37,10 @@ namespace BH.oM.Adapters.SAP2000
 
         [Description("Sets whether the loads being pushed should overwrite existing loads on the same object within the same loadcase")]
         public virtual bool ReplaceLoads { get; set; } = false;
+
+
+        [Description("If true, only Bar property assignments will be updated, ignoring changes to property definitions, geometry or other Bar assigns such as offsets, releases, etc. Non-existing objects will still be pushed.")]
+        public virtual bool UpdateOnlyBarPropAssigns { get; set; } = false;
 
         /***************************************************/
     }

--- a/SAP2000_oM/SAP2000_oM.csproj
+++ b/SAP2000_oM/SAP2000_oM.csproj
@@ -61,9 +61,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Config\SAP2000ActionConfig.cs" />
-	<Compile Include="Elements\AISCSteelUtilisation.cs" />
-	<Compile Include="Enums\SteelDesignCode.cs" />
+    <Compile Include="Config\SAP2000PushConfig.cs" />
+    <Compile Include="Elements\AISCSteelUtilisation.cs" />
+    <Compile Include="Enums\SteelDesignCode.cs" />
     <Compile Include="Enums\BarDesignProcedureType.cs" />
     <Compile Include="Enums\BarInsertionPointLocation.cs" />
     <Compile Include="Enums\SDShapeType.cs" />
@@ -73,7 +73,7 @@
     <Compile Include="Fragments\SAP2000Id.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Enums\ShellType.cs" />
-	<Compile Include="Requests\SteelUtilisationRequest.cs" />
+    <Compile Include="Requests\SteelUtilisationRequest.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #201 

<!-- Add short description of what has been fixed -->
added a new Update method which only updates bar property assigns, ignoring any geometry changes, property definitions, etc. to allow faster updates. Create will still be run for objects not in the model.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->