### PR TITLE
Fixing Load read/create bugs

### DIFF
--- a/SAP2000_Adapter/CRUD/Create/Loads.cs
+++ b/SAP2000_Adapter/CRUD/Create/Loads.cs
@@ -517,15 +517,14 @@ namespace BH.Adapter.SAP2000
             double[] forceVals = null;
             double[] momentVals = null;
             double dist = bhLoad.DistanceFromA;
-            if (dist > 1.0)
-                Engine.Reflection.Compute.RecordWarning("Please provide DistanceFromA as a relative distance (decimal between 0 and 1.0).");
-            bool relDist = true;
+            bool relDist = false; // BarPointLoad is defined as absolute distance from i (A) end of bar.
+            bool projected = bhLoad.Projected;
 
             // Determine coordinate system (local vs global) and set directions vector for CSI protocol
             switch (bhLoad.Axis)
             {
                 case LoadAxis.Global:
-                    dirs = new int[] { 4, 5, 6 };
+                    dirs = projected ? new int[] { 7, 8, 9 } : new int[] { 4, 5, 6 };
                     forceVals = bhLoad.Force.ToDoubleArray();
                     momentVals = bhLoad.Moment.ToDoubleArray();
                     break;
@@ -538,7 +537,7 @@ namespace BH.Adapter.SAP2000
 
             // Loop through bars and set point loads
             string cSys = bhLoad.Axis.ToCSI();
-            bool replace = true;
+            bool replace = SAPPushConfig.ReplaceLoads;
             eItemType type = eItemType.Objects;
             foreach (Bar bar in bars)
             {
@@ -592,6 +591,14 @@ namespace BH.Adapter.SAP2000
             SetAdapterId(bhLoad, null);
 
             return true;
+        }
+
+        /***************************************************/
+
+        private bool CreateLoad(ILoad bhLoad)
+        {
+            Engine.Reflection.Compute.RecordError($"TheLoad type {bhLoad.GetType()} is not implemented!");
+            return false;
         }
     }
 }

--- a/SAP2000_Adapter/CRUD/Read/Loads.cs
+++ b/SAP2000_Adapter/CRUD/Read/Loads.cs
@@ -156,8 +156,16 @@ namespace BH.Adapter.SAP2000
                 return ReadAreaLoad();
             else if (type == typeof(AreaUniformTemperatureLoad))
                 return ReadAreaUniformTemperatureLoad();
+            else if (type == typeof(ContourLoad))
+                return ReadContourLoad();
+            else if (type == typeof(GeometricalLineLoad))
+                return ReadGeometricalLineLoad();
             else if (type == typeof(PointDisplacement))
                 return ReadPointDispl();
+            else if (type == typeof(PointVelocity))
+                return ReadPointVelocity();
+            else if (type == typeof(PointAcceleration))
+                return ReadPointAcceleration();
             else if (type == typeof(GravityLoad))
                 return ReadGravityLoad();
             else
@@ -262,6 +270,22 @@ namespace BH.Adapter.SAP2000
 
         /***************************************************/
 
+        private List<ILoad> ReadPointVelocity(List<string> ids = null)
+        {
+            Engine.Reflection.Compute.RecordError("Read PointVelocity is not implemented!");
+            return new List<ILoad>();
+        }
+
+        /***************************************************/
+
+        private List<ILoad> ReadPointAcceleration(List<string> ids = null)
+        {
+            Engine.Reflection.Compute.RecordError("Read PointVelocity is not implemented!");
+            return new List<ILoad>();
+        }
+
+        /***************************************************/
+
         private List<ILoad> ReadBarUniformDistributedLoad(List<string> ids = null)
         {
             List<ILoad> loads = new List<ILoad>();
@@ -298,6 +322,7 @@ namespace BH.Adapter.SAP2000
                         double val = val1[i];
                         Vector force = new Vector();
                         LoadAxis axis = cSys[i].LoadAxisToBHoM();
+                        bool projected = false;
 
                         switch (dir[i])
                         {
@@ -319,8 +344,24 @@ namespace BH.Adapter.SAP2000
                             case 6:
                                 force.Z = val;
                                 break;
+                            case 7:
+                                force.X = val;
+                                projected = true;
+                                break;
+                            case 8:
+                                force.Y = val;
+                                projected = true;
+                                break;
+                            case 9:
+                                force.Z = val;
+                                projected = true;
+                                break;
                             case 10:
                                 force.Z = -val;
+                                break;
+                            case 11:
+                                force.Z = -val;
+                                projected = true;
                                 break;
                             default:
                                 Engine.Reflection.Compute.RecordWarning("That load direction is not supported. Dir = " + dir[i].ToString());
@@ -334,7 +375,8 @@ namespace BH.Adapter.SAP2000
                                     Force = force,
                                     Loadcase = bhomCases[caseNames[i]],
                                     Objects = new BHoMGroup<Bar>() { Elements = { bhomBar } },
-                                    Axis = axis
+                                    Axis = axis,
+                                    Projected = projected
                                 });
                                 break;
                             case 2:
@@ -343,7 +385,8 @@ namespace BH.Adapter.SAP2000
                                     Moment = force,
                                     Loadcase = bhomCases[caseNames[i]],
                                     Objects = new BHoMGroup<Bar>() { Elements = { bhomBar } },
-                                    Axis = axis
+                                    Axis = axis,
+                                    Projected = projected
                                 });
                                 break;
                             default:
@@ -399,6 +442,7 @@ namespace BH.Adapter.SAP2000
 
                         Vector forceA = new Vector();
                         Vector forceB = new Vector();
+                        bool projected = false;
 
                         switch (dir[i])
                         {
@@ -426,9 +470,29 @@ namespace BH.Adapter.SAP2000
                                 forceA.Z = val1[i];
                                 forceB.Z = val2[i];
                                 break;
+                            case 7:
+                                forceA.Z = val1[i];
+                                forceB.Z = val2[i];
+                                projected = true;
+                                break;
+                            case 8:
+                                forceA.Z = val1[i];
+                                forceB.Z = val2[i];
+                                projected = true;
+                                break;
+                            case 9:
+                                forceA.Z = val1[i];
+                                forceB.Z = val2[i];
+                                projected = true;
+                                break;
                             case 10:
                                 forceA.Z = -val1[i];
                                 forceB.Z = -val2[i];
+                                break;
+                            case 11:
+                                forceA.Z = val1[i];
+                                forceB.Z = val2[i];
+                                projected = true;
                                 break;
                             default:
                                 Engine.Reflection.Compute.RecordWarning("That load direction is not yet supported. Dir = " + dir[i].ToString());
@@ -447,7 +511,8 @@ namespace BH.Adapter.SAP2000
                                     Loadcase = bhomCases[caseNames[i]],
                                     Objects = new BHoMGroup<Bar>() { Elements = { bhomBar } },
                                     Axis = axis,
-                                    RelativePositions = false
+                                    RelativePositions = false,
+                                    Projected = projected
                                 });
                                 break;
                             case 2:
@@ -460,7 +525,8 @@ namespace BH.Adapter.SAP2000
                                     Loadcase = bhomCases[caseNames[i]],
                                     Objects = new BHoMGroup<Bar>() { Elements = { bhomBar } },
                                     Axis = axis,
-                                    RelativePositions = false
+                                    RelativePositions = false,
+                                    Projected = projected
                                 });
                                 break;
                             default:
@@ -684,28 +750,40 @@ namespace BH.Adapter.SAP2000
                     
                     Vector force = new Vector();
                     LoadAxis axis = cSys[i].LoadAxisToBHoM();
+                    bool projected = false;
+
                     switch (dir[i])
                     {
                         case 1:
-                            force.X = val[i];
-                            break;
-                        case 2:
-                            force.Y = val[i];
-                            break;
-                        case 3:
-                            force.Z = val[i];
-                            break;
                         case 4:
                             force.X = val[i];
                             break;
+                        case 2:
                         case 5:
                             force.Y = val[i];
                             break;
+                        case 3:
                         case 6:
                             force.Z = val[i];
+                            break;                        
+                        case 7:
+                            force.X = val[i];
+                            projected = true;
+                            break;
+                        case 8:
+                            force.Y = val[i];
+                            projected = true;
+                            break;
+                        case 9:
+                            force.Z = val[i];
+                            projected = true;
                             break;
                         case 10:
                             force.Z = -val[i];
+                            break;
+                        case 11:
+                            force.Z = -val[i];
+                            projected = true;
                             break;
                         default:
                             BH.Engine.Reflection.Compute.RecordWarning("That load direction is not supported. Dir = " + dir[i].ToString());
@@ -716,8 +794,9 @@ namespace BH.Adapter.SAP2000
                     {
                         Pressure = force,
                         Loadcase = bhomCases[caseNames[i]],
-                        Objects = new BHoMGroup<IAreaElement>() { Elements = { bhomPanel as IAreaElement} },
-                        Axis = axis
+                        Objects = new BHoMGroup<IAreaElement>() { Elements = { bhomPanel } },
+                        Axis = axis,
+                        Projected = projected
                     });
                 }
             }
@@ -799,12 +878,28 @@ namespace BH.Adapter.SAP2000
                     {
                         TemperatureChange = tempForce,
                         Loadcase = bhomCases[caseNames[i]],
-                        Objects = new BHoMGroup<IAreaElement>() { Elements = { bhomPanel as IAreaElement } },
+                        Objects = new BHoMGroup<IAreaElement>() { Elements = { bhomPanel } },
                         Axis = LoadAxis.Global
                     });
                 }
             }
             return loads;
+        }
+
+        /***************************************************/
+
+        private List<ILoad> ReadContourLoad(List<string> ids = null)
+        {
+            Engine.Reflection.Compute.RecordError("ContourLoads are mapped to Null Areas with AreaLoads, so we can't be sure the object was originally a ContourLoad or not - suggest pulling AreaUniformlyDistributedLoad and filtering for null properties.");
+            return new List<ILoad>();
+        }
+
+        /***************************************************/
+
+        private List<ILoad> ReadGeometricalLineLoad(List<string> ids = null)
+        {
+            Engine.Reflection.Compute.RecordError("GeometricalLineLoads are mapped to Null Frames with Uniform Loads, so we can't be sure the object was originally a GeometricalLineLoads or not - suggest pulling BarUniformlyDistributedLoad and filtering for null properties.");
+            return new List<ILoad>();
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #216
Closes #217
Closes #218 

<!-- Add short description of what has been fixed -->
Fixed un-handled missing load types in Create and Read - create would crash, read would return every load in the model.
Fixed BarPointLoad, which assumed a relative distance, rather than absolute.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BuroHappoldEngineering/Create%20Read%20Loads?csf=1&web=1&e=RgtJKt

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->