### PR TITLE
Added more options for attachment behavior to existing SAP instances

### DIFF
--- a/SAP2000_Adapter/SAP2000Adapter.cs
+++ b/SAP2000_Adapter/SAP2000Adapter.cs
@@ -100,7 +100,7 @@ namespace BH.Adapter.SAP2000
                     }
                     else
                     {
-                        if (m_model == null)
+                        if (m_model.GetModelFilename(false) == null)
                             RunCommand(new NewModel());
                         BH.Engine.Reflection.Compute.RecordWarning("File path is either not provided or invalid. " +
                                                         "BHoM is attached to the current SAP2000 instance.");
@@ -148,4 +148,3 @@ namespace BH.Adapter.SAP2000
         /***************************************************/
     }
 }
-

--- a/SAP2000_Adapter/SAP2000Adapter.cs
+++ b/SAP2000_Adapter/SAP2000Adapter.cs
@@ -100,7 +100,8 @@ namespace BH.Adapter.SAP2000
                     }
                     else
                     {
-                        RunCommand(new NewModel());
+                        if (m_model == null)
+                            RunCommand(new NewModel());
                         BH.Engine.Reflection.Compute.RecordWarning("File path is either not provided or invalid. " +
                                                         "BHoM is attached to the current SAP2000 instance.");
                     }

--- a/SAP2000_Adapter/SAP2000Adapter.cs
+++ b/SAP2000_Adapter/SAP2000Adapter.cs
@@ -132,6 +132,10 @@ namespace BH.Adapter.SAP2000
                     }
                 }
             }
+            else
+            {
+                BH.Engine.Reflection.Compute.RecordWarning("SAP2000 Adapter is not currently active.");
+            }
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/SAP2000Adapter.cs
+++ b/SAP2000_Adapter/SAP2000Adapter.cs
@@ -58,6 +58,12 @@ namespace BH.Adapter.SAP2000
 
                 Open openCommand = new Open();
 
+                if (System.Diagnostics.Process.GetProcessesByName("SAP2000").Length > 1)
+                {
+                    BH.Engine.Reflection.Compute.RecordError("More than one SAP2000 instance is open. BHoM will attach to the most recently updated process, " +
+                        "but you should only work with one SAP2000 instance at a time with BHoM.");
+                }
+
                 if (File.Exists(filePath))
                     openCommand.FileName = filePath;
 

--- a/SAP2000_Adapter/SAP2000Adapter.cs
+++ b/SAP2000_Adapter/SAP2000Adapter.cs
@@ -101,8 +101,7 @@ namespace BH.Adapter.SAP2000
                     else
                     {
                         BH.Engine.Reflection.Compute.RecordWarning("File path is either not provided or invalid. " +
-                            "Please save your SAP2000 model before proceeding. " +
-                            "BHoM is attached to the current SAP2000 instance.");
+                                                        "BHoM is attached to the current SAP2000 instance.");
                     }
                 }
                 catch
@@ -121,8 +120,7 @@ namespace BH.Adapter.SAP2000
                         {
                             RunCommand(new NewModel());
                             BH.Engine.Reflection.Compute.RecordWarning("File path is either not provided or invalid. " +
-                                "Please save your SAP2000 model before proceeding." +
-                                " BHoM is attached to the current SAP2000 instance.");
+                                                                "BHoM is attached to the current SAP2000 instance.");
                         }
                     }
                     catch

--- a/SAP2000_Adapter/SAP2000Adapter.cs
+++ b/SAP2000_Adapter/SAP2000Adapter.cs
@@ -100,6 +100,7 @@ namespace BH.Adapter.SAP2000
                     }
                     else
                     {
+                        RunCommand(new NewModel());
                         BH.Engine.Reflection.Compute.RecordWarning("File path is either not provided or invalid. " +
                                                         "BHoM is attached to the current SAP2000 instance.");
                     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #225 

<!-- Add short description of what has been fixed -->
Additional case handling has been added for if SAP2000 is already open.

### Test files
<!-- Link to test files to validate the proposed changes -->
Hard to create a test file for this but the cases that should be tested are:
- no filepath provided, SAP2000 is open
  - BHoM should attach to open SAP program
- filepath provided and matches open SAP2000 model, SAP2000 is open
  - BHoM should attach to open SAP program (and not reload the open file)
- filepath provided and does not match open SAP2000 model, SAP2000 is open 
  - BHoM should attach to open SAP program, save open model, then load new model.
- filepath provided, SAP2000 is not open 
  - BHoM should open SAP
- filepath not provided, SAP2000 is not open 
  - BHoM should open SAP

![image](https://user-images.githubusercontent.com/58230980/114632271-30460780-9c73-11eb-8946-f4cbace6abcd.png)