### PR TITLE
Add null check for node orientation when creating or updating nodes

### DIFF
--- a/SAP2000_Adapter/CRUD/Create/Node.cs
+++ b/SAP2000_Adapter/CRUD/Create/Node.cs
@@ -96,7 +96,7 @@ namespace BH.Adapter.SAP2000
                 }
             }
 
-            if (!bhNode.Orientation.Equals(Basis.XY))
+            if (bhNode.Orientation != null && !bhNode.Orientation.Equals(Basis.XY))
             {
                 int myVectOpt = 3; //specify orientation by vectors
                 string globalCSys = "GLOBAL"; //specify point orientation relative to the global coordinate system

--- a/SAP2000_Adapter/CRUD/Create/Node.cs
+++ b/SAP2000_Adapter/CRUD/Create/Node.cs
@@ -96,20 +96,28 @@ namespace BH.Adapter.SAP2000
                 }
             }
 
-            if (bhNode.Orientation != null && !bhNode.Orientation.Equals(Basis.XY))
+            if (bhNode.Orientation != null)
             {
-                int myVectOpt = 3; //specify orientation by vectors
-                string globalCSys = "GLOBAL"; //specify point orientation relative to the global coordinate system
-                int[] myDir = { 1, 2 }; //not used for VecOpt = 3
-                string[] noPts = { "None", "None" }; //not used for VecOpt = 3
-                int myPlane2 = 12; //specify point orientation by local 1(X) and 2(Y) vectors
-                double[] myAxVect = bhNode.Orientation.X.ToDoubleArray();
-                double[] myPlVect = bhNode.Orientation.Y.ToDoubleArray();
+                if (bhNode.Orientation.IsEqual(Basis.XY))
+                {
+                    if (m_model.PointObj.SetLocalAxes(name, 0, 0, 0) != 0) //Set orientation to Global coordinate system
+                        CreatePropertyWarning("Node Local Axes", "Node", name);
+                }
+                else
+                {
+                    int myVectOpt = 3; //specify orientation by vectors
+                    string globalCSys = "GLOBAL"; //specify point orientation relative to the global coordinate system
+                    int[] myDir = { 1, 2 }; //not used for VecOpt = 3
+                    string[] noPts = { "None", "None" }; //not used for VecOpt = 3
+                    int myPlane2 = 12; //specify point orientation by local 1(X) and 2(Y) vectors
+                    double[] myAxVect = bhNode.Orientation.X.ToDoubleArray();
+                    double[] myPlVect = bhNode.Orientation.Y.ToDoubleArray();
 
-                if (m_model.PointObj.SetLocalAxesAdvanced(name, true,
-                        myVectOpt, globalCSys, ref myDir, ref noPts, ref myAxVect, myPlane2,
-                        myVectOpt, globalCSys, ref myDir, ref noPts, ref myPlVect) != 0)
-                    CreatePropertyWarning("Node Local Axes", "Node", name);
+                    if (m_model.PointObj.SetLocalAxesAdvanced(name, true,
+                            myVectOpt, globalCSys, ref myDir, ref noPts, ref myAxVect, myPlane2,
+                            myVectOpt, globalCSys, ref myDir, ref noPts, ref myPlVect) != 0)
+                        CreatePropertyWarning("Node Local Axes", "Node", name);
+                }
             }
 
             foreach (string gName in bhNode.Tags)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #230

<!-- Add short description of what has been fixed -->

Required before https://github.com/BHoM/BHoM/pull/1184 can be merged

### Test files
<!-- Link to test files to validate the proposed changes -->
[Push and update node with orientation](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/SAP2000_Toolkit/%23231-AddNullCheckForNodeOrientation?csf=1&web=1&e=zM80Vb)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->