### PR TITLE
Panel to return empty list of openings instead of null

### DIFF
--- a/SAP2000_Adapter/CRUD/Read/Panel.cs
+++ b/SAP2000_Adapter/CRUD/Read/Panel.cs
@@ -77,9 +77,8 @@ namespace BH.Adapter.SAP2000
                     bhomPanel.ExternalEdges = outEdges;
                 }
 
-                //Ignore the openings
-                List<Opening> noOpenings = null;
-                bhomPanel.Openings = noOpenings;
+                //There are no openings in SAP2000 
+                bhomPanel.Openings = new List<Opening>();
                 
                 //Get the section property
                 string propertyName = "";


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #232 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/SAP2000_Toolkit/%23233%20empty%20panel%20vs%20null/PR233%20pull%20panels.gh?csf=1&web=1&e=B9F0oe

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->