### PR TITLE
SAP2000: Change IAverageThickness to ITotalThickness()

### DIFF
--- a/SAP2000_Adapter/CRUD/Read/Loads.cs
+++ b/SAP2000_Adapter/CRUD/Read/Loads.cs
@@ -863,12 +863,12 @@ namespace BH.Adapter.SAP2000
                     {
                         try
                         {
-                            double avgConstTemp = 0.5 * tempForce * bhomPanel.Property.IAverageThickness();
+                            double avgConstTemp = 0.5 * tempForce * bhomPanel.Property.ITotalThickness();
                             tempForce = avgConstTemp;
                         }
                         catch { }
 
-                        Engine.Base.Compute.RecordWarning("Temperature gradient not currently implemented in the BHoM. An attempt has been made to convert SAP2000's gradient to a constant temperature change.");
+                        Engine.Base.Compute.RecordWarning("Temperature gradient not yet implemented. An attempt has been made to convert SAP2000's gradient to a constant temperature change.");
                     }
 
                     loads.Add(new AreaUniformTemperatureLoad()


### PR DESCRIPTION
Updated error message- area temperature gradients are now implemented in BHoM, raise issue in SAP to support.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Engine/pull/2819
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Average thickness is repurposed in the Structure_Engine. Instead relying on the ITotalThickness which is appropriate for a temperature gradient.

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->