### PR TITLE
Improve Nodes Move Algorithm

### DIFF
--- a/SAP2000_Adapter/CRUD/Create/Node.cs
+++ b/SAP2000_Adapter/CRUD/Create/Node.cs
@@ -77,6 +77,7 @@ namespace BH.Adapter.SAP2000
         {
             string name = GetAdapterId<string>(bhNode);
 
+            // 1. ASSIGN SUPPORT (RESTRAINT/SPRING)
             if (bhNode.Support != null)
             {
                 bool[] restraint = new bool[6];
@@ -96,6 +97,7 @@ namespace BH.Adapter.SAP2000
                 }
             }
 
+            // 2. ASSIGN ORIENTATION
             if (bhNode.Orientation != null)
             {
                 if (bhNode.Orientation.IsEqual(Basis.XY))
@@ -120,6 +122,7 @@ namespace BH.Adapter.SAP2000
                 }
             }
 
+            // 3. ASSIGN GROUP
             foreach (string gName in bhNode.Tags)
             {
                 string groupName = gName.ToString();

--- a/SAP2000_Adapter/CRUD/Update/Node.cs
+++ b/SAP2000_Adapter/CRUD/Update/Node.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
  *
@@ -20,8 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Structure;
 using BH.oM.Structure.Elements;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BH.Adapter.SAP2000
 {
@@ -34,40 +36,109 @@ namespace BH.Adapter.SAP2000
         private bool UpdateObjects(IEnumerable<Node> nodes)
         {
             bool success = true;
+
             m_model.SelectObj.ClearSelection();
 
             Engine.Structure.NodeDistanceComparer comparer = AdapterComparers[typeof(Node)] as Engine.Structure.NodeDistanceComparer;
 
             foreach (Node bhNode in nodes)
             {
+                // Retrieve node's updated unique name
                 string name = GetAdapterId<string>(bhNode);
 
+                // Update Supports, Orientation and Group
                 SetObject(bhNode);
-
-                double x = 0;
-                double y = 0;
-                double z = 0;
-
-                if (m_model.PointObj.GetCoordCartesian(name, ref x, ref y, ref z) == 0)
-                {
-                    oM.Geometry.Point p = new oM.Geometry.Point() { X = x, Y = y, Z = z };
-
-                    if (!comparer.Equals(bhNode, (Node)p))
-                    {
-                        x = bhNode.Position.X - x;
-                        y = bhNode.Position.Y - y;
-                        z = bhNode.Position.Z - z;
-
-                        m_model.PointObj.SetSelected(name, true);
-                        m_model.EditGeneral.Move(x, y, z);
-                        m_model.PointObj.SetSelected(name, false);
-                    }
-                }
             }
+
+            UpdateNodesPosition(comparer, nodes);
 
             return success;
 
         }
+
+        /***************************************************/
+
+        private bool UpdateNodesPosition(NodeDistanceComparer comparer, IEnumerable<Node> nodes)    // θ(n)
+        {
+            Dictionary<double, List<string>> dx = new Dictionary<double, List<string>>();           // θ(1)
+            Dictionary<double, List<string>> dy = new Dictionary<double, List<string>>();           // θ(1)
+            Dictionary<double, List<string>> dz = new Dictionary<double, List<string>>();           // θ(1)
+
+            // 1. GROUP NODES BY RELATIVE MOVEMENT IN X/Y/Z DIRECTION  -  ** HASH TABLES **
+
+            foreach (Node bhNode in nodes)                                                          // n*θ(1) + θ(1)
+            {
+                string name = GetAdapterId<string>(bhNode);                                         // θ(1)
+
+                // Update position
+                double x = 0;                                                                       // θ(1)
+                double y = 0;                                                                       // θ(1)
+                double z = 0;                                                                       // θ(1)
+
+                if (m_model.PointObj.GetCoordCartesian(name, ref x, ref y, ref z) == 0)             // θ(1)
+                {
+                    oM.Geometry.Point p = new oM.Geometry.Point() { X = x, Y = y, Z = z };          // θ(1)
+
+                    if (!comparer.Equals(bhNode, (Node)p))                                          // θ(1)
+                    {
+                        // Get BHoM vs ETABS differences in nodes coordinates
+                        x = bhNode.Position.X - x;                                                  // θ(1)
+                        y = bhNode.Position.Y - y;                                                  // θ(1)
+                        z = bhNode.Position.Z - z;                                                  // θ(1)
+
+                        // Add Node name and corresponding dX in dx Hash Table
+                        if (dx.ContainsKey(x)) dx[x].Add(name);                                     // θ(1)
+                        else dx.Add(x, new List<string>() { name });                                // θ(1)
+                        // Add Node name and corresponding dY in dy Hash Table
+                        if (dy.ContainsKey(y)) dy[y].Add(name);                                     // θ(1)
+                        else dy.Add(y, new List<string>() { name });                                // θ(1)
+                        // Add Node name and corresponding dZ in dz Hash Table
+                        if (dz.ContainsKey(z)) dz[z].Add(name);                                     // θ(1)
+                        else dz.Add(z, new List<string>() { name });                                // θ(1)
+
+                    }
+                }
+            }
+
+            // 2. MOVE NODES GROUP-BY-GROUP  -  ** STREAMS **
+
+            // dX Movement
+            dx.ToList().ForEach(kvp =>                                                              // θ(n)
+            {
+                // 1. Select all nodes belonging to same group
+                kvp.Value.ForEach(pplbl => m_model.PointObj.SetSelected(pplbl.ToString(), true));
+                // 2. Move all selected nodes by same dX
+                m_model.EditGeneral.Move((double)kvp.Key, 0, 0);
+                // 3. Deselect all selected nodes
+                kvp.Value.ForEach(pplbl => m_model.PointObj.SetSelected(pplbl.ToString(), false));
+            });
+
+            // dY Movement
+            dy.ToList().ForEach(kvp =>                                                              // θ(n)
+            {
+                // 1. Select all nodes belonging to same group
+                kvp.Value.ForEach(pplbl => m_model.PointObj.SetSelected(pplbl.ToString(), true));
+                // 2. Move all selected nodes by same dY
+                m_model.EditGeneral.Move(0, (double)kvp.Key, 0);
+                // 3. Deselect all selected nodes
+                kvp.Value.ForEach(pplbl => m_model.PointObj.SetSelected(pplbl.ToString(), false));
+            });
+
+            // dZ Movement
+            dz.ToList().ForEach(kvp =>                                                              // θ(n)
+            {
+                // 1. Select all nodes belonging to same group
+                kvp.Value.ForEach(pplbl => m_model.PointObj.SetSelected(pplbl.ToString(), true));
+                // 2. Move all selected nodes by same dZ
+                m_model.EditGeneral.Move(0, 0, (double)kvp.Key);
+                // 3. Deselect all selected nodes
+                kvp.Value.ForEach(pplbl => m_model.PointObj.SetSelected(pplbl.ToString(), false));
+            });
+
+            return true;
+        }
+
+        /***************************************************/
 
     }
 }

--- a/SAP2000_Adapter/CRUD/Update/_IUpdate.cs
+++ b/SAP2000_Adapter/CRUD/Update/_IUpdate.cs
@@ -40,14 +40,22 @@ namespace BH.Adapter.SAP2000
         {
             this.SAPPushConfig = actionConfig as SAP2000PushConfig;
 
+            bool success = false;
+
             if (SAPPushConfig != null && SAPPushConfig.UpdateOnlyBarPropAssigns) // Only update bar assigns
             {
                 return UpdateBarPropAssigns(objects.OfType<Bar>());
             }
             else
             {
-                return UpdateObjects(objects as dynamic);
+                success = UpdateObjects(objects as dynamic);
+
+                // Refresh Model View to show updated
+                m_model.View.RefreshView();
+
+                return success;
             }
+
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/SAP2000Adapter.cs
+++ b/SAP2000_Adapter/SAP2000Adapter.cs
@@ -57,12 +57,6 @@ namespace BH.Adapter.SAP2000
 
             if (active)
             {
-                if(Environment.Version.Major > 4)
-                {
-                    Engine.Base.Compute.RecordError($"The SAP2000Adapter is currently not support in NET runtimes above .NETFramework due to internal errors in the SAP2000 API. A fix for this is being worked on. \n" +
-                        $"If you are running this adapter from Grasshopper in Rhino 8, you can change the runtime being used by Rhino to .NETFramework. To do this please follow the instructions here: https://www.rhino3d.com/en/docs/guides/netcore/");
-                }
-
                 string progId = "CSI.SAP2000.API.SapObject";
                 cHelper helper = new Helper();
 


### PR DESCRIPTION
### Issues addressed by this PR

 Closes #325 

SAP2000 Toolkit now able to perform translational movement of model objects upon Update Request much faster than before.
Whenever rotations or distorsions of ETABS objects are concerned, unfortunately ETABS API limitations still prevent BHoM from carrying out a correct update of ETABS panel objects.
More work is required to find out a solution to this problem.


 ### Test files
Video Demonstration - Issue

Video Demonstration - Solution

Grasshopper File

SAP2000 File


 ### Changelog

- Use of Hash Tables to store and access faster data for moving nodes
- Use of Streams on Hash Tables to run the SAP2000 API .move() method faster on nodes grouped together