### PR TITLE
Remove Net runtimes error message in Adapter

### DIFF
--- a/SAP2000_Adapter/SAP2000Adapter.cs
+++ b/SAP2000_Adapter/SAP2000Adapter.cs
@@ -57,12 +57,6 @@ namespace BH.Adapter.SAP2000
 
             if (active)
             {
-                if(Environment.Version.Major > 4)
-                {
-                    Engine.Base.Compute.RecordError($"The SAP2000Adapter is currently not support in NET runtimes above .NETFramework due to internal errors in the SAP2000 API. A fix for this is being worked on. \n" +
-                        $"If you are running this adapter from Grasshopper in Rhino 8, you can change the runtime being used by Rhino to .NETFramework. To do this please follow the instructions here: https://www.rhino3d.com/en/docs/guides/netcore/");
-                }
-
                 string progId = "CSI.SAP2000.API.SapObject";
                 cHelper helper = new Helper();
 


### PR DESCRIPTION
### Issues addressed by this PR
Removes superseded error message in the Adapter regarding issues with compatibility with NET runtimes higher than .NET Framework. The issue doesn't exist anymore.

Closes #346 

### Changelog
- Removed RecordError in SAP2000Adapter