### PR TITLE
Add Support for Editing Obj Names

### DIFF
--- a/SAP2000_Adapter/CRUD/Create/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Create/Bar.cs
@@ -70,20 +70,20 @@ namespace BH.Adapter.SAP2000
                 return false;
             }
 
-            // Set AdapterID
-            if (name != bhBar.Name & bhBar.Name != "")
-                Engine.Base.Compute.RecordNote($"Bar {bhBar.Name} was assigned SAP2000_id of {name}");
+            // Assign the Unique Name to the SAP2000 Element
+            string newName = SetUniqueName(bhBar, name);
+
+            if (newName == null) return false;
 
             string guid = null;
-            m_model.FrameObj.GetGUID(name, ref guid);
+            m_model.FrameObj.GetGUID(newName, ref guid);
 
-            SAP2000Id sap2000IdFragment = new SAP2000Id { Id = name, PersistentId = guid };
+            SAP2000Id sap2000IdFragment = new SAP2000Id { Id = newName, PersistentId = guid };
             bhBar.SetAdapterId(sap2000IdFragment);
 
             // Set Properties
-            SetObject(bhBar);
+            return SetObject(bhBar);
 
-            return true;
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/CRUD/Create/Node.cs
+++ b/SAP2000_Adapter/CRUD/Create/Node.cs
@@ -55,20 +55,20 @@ namespace BH.Adapter.SAP2000
                 return false;
             }
 
+            // Assign the Unique Name to the SAP2000 Element
+            string newName = SetUniqueName(bhNode, name);
+
+            if (newName == null) return false;
+
             // Set Adapter ID
-            if (name != bhNode.Name & bhNode.Name != "")
-                Engine.Base.Compute.RecordNote($"Node {bhNode.Name} was assigned SAP2000_id of {name}");
-
             string guid = null;
-            m_model.PointObj.GetGUID(name, ref guid);
+            m_model.PointObj.GetGUID(newName, ref guid);
 
-            SAP2000Id sap2000IdFragment = new SAP2000Id { Id = name, PersistentId = guid };
+            SAP2000Id sap2000IdFragment = new SAP2000Id { Id = newName, PersistentId = guid };
             bhNode.SetAdapterId(sap2000IdFragment);
 
             // Set Properties
-            SetObject(bhNode);            
-
-            return true;            
+            return SetObject(bhNode);                      
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/CRUD/Create/Panel.cs
+++ b/SAP2000_Adapter/CRUD/Create/Panel.cs
@@ -67,17 +67,18 @@ namespace BH.Adapter.SAP2000
                 return false;
             }
 
-            // Set AdapterID
-            if (name != bhPanel.Name & bhPanel.Name != "")
-                Engine.Base.Compute.RecordNote($"Panel {bhPanel.Name} was assigned SAP2000_id of {name}.");
+            // Assign the Unique Name to the SAP2000 Element
+            string newName = SetUniqueName(bhPanel, name);
 
+            if (newName == null) return false;
+
+            // Set AdapterID
             string guid = null;
-            m_model.AreaObj.GetGUID(name, ref guid);
-            SAP2000Id sap2000IdFragment = new SAP2000Id{Id = name, PersistentId = guid};
+            m_model.AreaObj.GetGUID(newName, ref guid);
+            SAP2000Id sap2000IdFragment = new SAP2000Id{Id = newName, PersistentId = guid};
             bhPanel.SetAdapterId(sap2000IdFragment);
             // Set Properties
-            SetObject(bhPanel);
-            return true;
+            return SetObject(bhPanel);
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/CRUD/Create/RigidLink.cs
+++ b/SAP2000_Adapter/CRUD/Create/RigidLink.cs
@@ -24,6 +24,7 @@ using BH.Engine.Adapter;
 using BH.oM.Adapters.SAP2000;
 using BH.oM.Structure.Elements;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.Adapter.SAP2000
 {
@@ -90,6 +91,47 @@ namespace BH.Adapter.SAP2000
             bhLink.SetAdapterId(sap2000id);
 
             return true;
+        }
+
+        /***************************************************/
+
+        [Description("Concatenates the last 7 characters of the SAP2000 Element GUID and the Link Name to get the Unique Name to assign to the SAP2000 Element.")]
+        private List<string> SetUniqueName(RigidLink bhLink, List<string> names)
+        {
+
+            int ret01, ret02;
+            string guid = null;
+            string tempLinkName = "";
+            List<string> newLinkNames = new List<string>();
+
+            foreach (string name in names)
+            {
+
+                /* 1. GET THE SAP2000 ELEMENT GUID */
+                tempLinkName = "";
+                ret01 = m_model.LinkObj.GetGUID(name, ref guid);
+
+                /* 2. CREATE THE NEW UNIQUE NAME */
+                if (bhLink.Name == "")
+                {
+                    tempLinkName = guid.Substring(guid.Length - 7);
+                }
+                else
+                {
+                    tempLinkName = bhLink.Name + "::" + guid.Substring(guid.Length - 7);
+                }
+
+                /* 3. ASSIGN THE NEW UNIQUE NAME TO THE SAP2000 ELEMENT */
+                ret02 = m_model.LinkObj.ChangeName(name, tempLinkName);
+
+                /* 4. ADD THE NEW NAME TO THE LIST */
+                newLinkNames.Add(tempLinkName);
+
+                if (!(ret01 == 0 && ret02 == 0)) return null;
+
+            }
+
+            return newLinkNames;
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/CRUD/Create/RigidLink.cs
+++ b/SAP2000_Adapter/CRUD/Create/RigidLink.cs
@@ -87,7 +87,12 @@ namespace BH.Adapter.SAP2000
                 }
             }
 
-            sap2000id.Id = linkIds;
+            // Assign the Unique Name to the SAP2000 Element
+            List<string> newLinkNames = SetUniqueName(bhLink, linkIds);
+
+            if (newLinkNames == null) return false;
+
+            sap2000id.Id = newLinkNames;
             bhLink.SetAdapterId(sap2000id);
 
             return true;

--- a/SAP2000_Adapter/CRUD/Create/_ICreate.cs
+++ b/SAP2000_Adapter/CRUD/Create/_ICreate.cs
@@ -47,6 +47,8 @@ namespace BH.Adapter.SAP2000
 
         protected override bool ICreate<T>(IEnumerable<T> objects, ActionConfig actionConfig)
         {
+            bool success = true;
+
             this.SAPPushConfig = actionConfig as SAP2000PushConfig;
 
             if (!objects.Any()) //Return if no objects

--- a/SAP2000_Adapter/CRUD/Create/_ICreate.cs
+++ b/SAP2000_Adapter/CRUD/Create/_ICreate.cs
@@ -89,6 +89,50 @@ namespace BH.Adapter.SAP2000
         }
 
         /***************************************************/
+
+        [Description("Concatenates the the BHoM Object Name and the last 7 characters of the SAP2000 Element GUID to get the Unique Name to assign to the SAP2000 Element.")]
+        private string SetUniqueName(BHoMObject obj, string name)
+        {
+            /* 1. CHECK OBJECT TYPE IS ACCEPTABLE */
+            if (!(obj.GetType() == typeof(Node) ||
+                  obj.GetType() == typeof(Bar) ||
+                  obj.GetType() == typeof(Panel) ||
+                  obj.GetType() == typeof(Opening)))
+            {
+                return null;
+            }
+
+            /* 2. GET THE SAP2000 ELEMENT GUID */
+            int ret01 = 1;
+            int ret02 = 1;
+            string guid = null;
+            string tempObjName = "";
+
+            if (obj.GetType() == typeof(Node)) ret01 = m_model.PointObj.GetGUID(name, ref guid);
+            if (obj.GetType() == typeof(Bar)) ret01 = m_model.FrameObj.GetGUID(name, ref guid);
+            if (obj.GetType() == typeof(Panel) || obj.GetType() == typeof(Opening)) ret01 = m_model.AreaObj.GetGUID(name, ref guid);
+
+            /* 3. CREATE THE NEW UNIQUE NAME */
+            if (obj.Name == "")
+            {
+                tempObjName = guid.Substring(guid.Length - 7);
+            }
+            else
+            {
+                tempObjName = obj.Name + "::" + guid.Substring(guid.Length - 7);
+            }
+
+            /* 4. ASSIGN THE NEW UNIQUE NAME TO THE SAP2000 ELEMENT */
+            if (obj.GetType() == typeof(Node)) ret02 = m_model.PointObj.ChangeName(name, tempObjName);
+            if (obj.GetType() == typeof(Bar)) ret02 = m_model.FrameObj.ChangeName(name, tempObjName);
+            if (obj.GetType() == typeof(Panel) || obj.GetType() == typeof(Opening)) ret02 = m_model.AreaObj.ChangeName(name, tempObjName);
+
+            if (!(ret01 == 0 && ret02 == 0)) return null;
+
+            return tempObjName;
+
+            /***************************************************/
+        }
     }
 }
 

--- a/SAP2000_Adapter/CRUD/Create/_ICreate.cs
+++ b/SAP2000_Adapter/CRUD/Create/_ICreate.cs
@@ -63,7 +63,9 @@ namespace BH.Adapter.SAP2000
                 success = false;
             }
 
-            m_model.View.RefreshView();
+            // Refresh the view to ensure that the newly created objects are displayed correctly
+            m_model.View.RefreshView(0, false);
+
             return success;
         }
 

--- a/SAP2000_Adapter/CRUD/Create/_ICreate.cs
+++ b/SAP2000_Adapter/CRUD/Create/_ICreate.cs
@@ -122,7 +122,7 @@ namespace BH.Adapter.SAP2000
             if (obj.GetType() == typeof(Bar)) ret02 = m_model.FrameObj.ChangeName(name, tempObjName);
             if (obj.GetType() == typeof(Panel) || obj.GetType() == typeof(Opening)) ret02 = m_model.AreaObj.ChangeName(name, tempObjName);
 
-            if (!(ret01 == 0 && ret02 == 0)) return null;
+            if (!(ret01 == 0 && ret02 == 0)) return "";
 
             return tempObjName;
 

--- a/SAP2000_Adapter/CRUD/Create/_ICreate.cs
+++ b/SAP2000_Adapter/CRUD/Create/_ICreate.cs
@@ -110,21 +110,12 @@ namespace BH.Adapter.SAP2000
             int ret01 = 1;
             int ret02 = 1;
             string guid = null;
-            string tempObjName = "";
 
             if (obj.GetType() == typeof(Node)) ret01 = m_model.PointObj.GetGUID(name, ref guid);
             if (obj.GetType() == typeof(Bar)) ret01 = m_model.FrameObj.GetGUID(name, ref guid);
             if (obj.GetType() == typeof(Panel) || obj.GetType() == typeof(Opening)) ret01 = m_model.AreaObj.GetGUID(name, ref guid);
 
-            /* 3. CREATE THE NEW UNIQUE NAME */
-            if (obj.Name == "")
-            {
-                tempObjName = guid.Substring(guid.Length - 7);
-            }
-            else
-            {
-                tempObjName = obj.Name + "::" + guid.Substring(guid.Length - 7);
-            }
+            string tempObjName = obj.Name == "" ? guid.Substring(guid.Length - 7) : obj.Name + "::" + guid.Substring(guid.Length - 7);
 
             /* 4. ASSIGN THE NEW UNIQUE NAME TO THE SAP2000 ELEMENT */
             if (obj.GetType() == typeof(Node)) ret02 = m_model.PointObj.ChangeName(name, tempObjName);

--- a/SAP2000_Adapter/CRUD/Create/_ICreate.cs
+++ b/SAP2000_Adapter/CRUD/Create/_ICreate.cs
@@ -20,21 +20,22 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapter;
+using BH.oM.Adapters.SAP2000;
+using BH.oM.Analytical;
 using BH.oM.Base;
 using BH.oM.Dimensional;
+using BH.oM.Structure.Constraints;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Loads;
-using BH.oM.Structure.Constraints;
+using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.SurfaceProperties;
-using BH.oM.Structure.MaterialFragments;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
-using BH.oM.Analytical;
-using BH.oM.Adapter;
-using BH.oM.Adapters.SAP2000;
 
 namespace BH.Adapter.SAP2000
 {
@@ -48,14 +49,20 @@ namespace BH.Adapter.SAP2000
         {
             this.SAPPushConfig = actionConfig as SAP2000PushConfig;
 
+            if (!objects.Any()) //Return if no objects
+                return true;
+
             if (typeof(BH.oM.Base.IBHoMObject).IsAssignableFrom(typeof(T)))
             {
-                return (CreateCollection(objects));
+                success = CreateCollection(objects);
             }
             else
             {
-                return false;
+                success = false;
             }
+
+            m_model.View.RefreshView();
+            return success;
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/CRUD/Read/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Read/Bar.cs
@@ -60,7 +60,11 @@ namespace BH.Adapter.SAP2000
 
                 try
                 {
-                    Bar bhomBar = new Bar();
+
+                    string bhomName = GetBhomNameFromSAP2000Id(id);
+
+                    Bar bhomBar = new Bar() { Name = bhomName };
+
                     string startId = "";
                     string endId = "";
                     m_model.FrameObj.GetPoints(id, ref startId, ref endId);

--- a/SAP2000_Adapter/CRUD/Read/Node.cs
+++ b/SAP2000_Adapter/CRUD/Read/Node.cs
@@ -52,7 +52,10 @@ namespace BH.Adapter.SAP2000
 
             foreach (string id in ids)
             {
-                Node bhNode = new Node();
+                string bhomName = GetBhomNameFromSAP2000Id(id);
+
+                Node bhNode = new Node { Name = bhomName};
+
                 string guid = null;
                 SAP2000Id sap2000id = new SAP2000Id();
                 sap2000id.Id = id;

--- a/SAP2000_Adapter/CRUD/Read/Panel.cs
+++ b/SAP2000_Adapter/CRUD/Read/Panel.cs
@@ -52,7 +52,9 @@ namespace BH.Adapter.SAP2000
             ids = FilterIds(ids, nameArr);
             foreach (string id in ids)
             {
-                Panel bhomPanel = new Panel();
+                string bhomName = GetBhomNameFromSAP2000Id(id);
+                Panel bhomPanel = new Panel() { Name = bhomName };
+
                 SAP2000Id sap2000id = new SAP2000Id();
                 string guid = null;
                 //Set the Adapter ID

--- a/SAP2000_Adapter/CRUD/Read/RigidLink.cs
+++ b/SAP2000_Adapter/CRUD/Read/RigidLink.cs
@@ -39,81 +39,126 @@ namespace BH.Adapter.SAP2000
         private List<RigidLink> ReadRigidLink(List<string> ids = null)
         {
             List<RigidLink> linkList = new List<RigidLink>();
-            Dictionary<string, Node> bhomNodes = ReadNodes().ToDictionary(x => GetAdapterId<string>(x));
-            Dictionary<string, LinkConstraint> bhomLinkConstraints = ReadLinkConstraints().ToDictionary(x => GetAdapterId<string>(x));
 
-
-            //Read all links, filter by id at end, so that we can join multi-links.
             int nameCount = 0;
-            string[] nameArr = { };
-            m_model.LinkObj.GetNameList(ref nameCount, ref nameArr);
+            string[] names = { };
+            m_model.LinkObj.GetNameList(ref nameCount, ref names);
 
+            ids = FilterIds(ids, names);
 
+            //read primary-multiSecondary nodes if these were initially created from (non-etabs)BHoM side
+            Dictionary<string, List<string>> idDict = new Dictionary<string, List<string>>();
+            string[] primarySecondaryId;
 
-            foreach (string id in nameArr)
+            foreach (string id in ids)
             {
-                RigidLink newLink = new RigidLink();
-                SAP2000Id sap2000id = new SAP2000Id();
-                string guid = null;
-
-                sap2000id.Id = id;
-
-                try
+                primarySecondaryId = id.Split(new[] { ":::" }, StringSplitOptions.None);
+                if (primarySecondaryId.Count() > 1)
                 {
-                    string primaryId = "";
-                    string secondaryId = "";
-                    string propName = "";
-                    m_model.LinkObj.GetPoints(id, ref primaryId, ref secondaryId);
-                    newLink.PrimaryNode = bhomNodes[primaryId];
-                    newLink.SecondaryNodes = new List<Node> { bhomNodes[secondaryId] };
-
-                    if (m_model.LinkObj.GetProperty(id, ref propName) == 0)
-                    {
-                        LinkConstraint bhProp = new LinkConstraint();
-                        bhomLinkConstraints.TryGetValue(propName, out bhProp);
-                        newLink.Constraint = bhProp; m_model.LinkObj.GetProperty(id, ref propName);
-                    }
+                    //has plural secondaries
+                    if (idDict.ContainsKey(primarySecondaryId[0]))
+                        idDict[primarySecondaryId[0]].Add(primarySecondaryId[1]);
                     else
-                    {
-                        Engine.Base.Compute.RecordWarning("Could not get link property for RigidLink " + id + ".");
-                    }
-                    
-                    // Get the groups the link is assigned to
-                    int numGroups = 0;
-                    string[] groupNames = new string[0];
-                    if (m_model.LinkObj.GetGroupAssign(id, ref numGroups, ref groupNames) == 0)
-                    {
-                        foreach (string grpName in groupNames)
-                            newLink.Tags.Add(grpName);
-                    }
-
-                    if (m_model.LinkObj.GetGUID(id, ref guid) == 0)
-                        sap2000id.PersistentId = guid;
-
-                    newLink.SetAdapterId(sap2000id);
-                    linkList.Add(newLink);
+                        idDict.Add(primarySecondaryId[0], new List<string>() { primarySecondaryId[1] });
                 }
-
-                catch
+                else
                 {
-                    ReadElementError("RigidLink", id.ToString());
+                    //normal single link
+                    idDict.Add(id, null);
                 }
             }
 
-            Dictionary<string, RigidLink> joinedLinks = BH.Engine.Adapters.SAP2000.Query.JoinRigidLink(linkList).ToDictionary(x => x.Name);
 
-            ids = FilterIds(ids, joinedLinks.Keys);
+            foreach (KeyValuePair<string, List<string>> kvp in idDict)
+            {
+                string bhomName = GetBhomNameFromSAP2000Id(kvp.Key);
 
-            if (ids != null)
-            {
-                return joinedLinks
-                     .Where(x => ids.Contains(x.Key))
-                     .Select(x => x.Value).ToList();
+                RigidLink bhLink = new RigidLink() { Name = bhomName };
+
+                SetAdapterId(bhLink, kvp.Key);
+
+                if (kvp.Value == null)
+                {
+                    string startId = "";
+                    string endId = "";
+                    m_model.LinkObj.GetPoints(kvp.Key, ref startId, ref endId);
+
+                    //Dummy nodes with correct Id
+                    bhLink.PrimaryNode = new Node { Name = startId };
+                    bhLink.SecondaryNodes = new List<Node>() { new Node { Name = endId } };
+                }
+                else
+                {
+                    string startId = "";
+                    string endId = "";
+                    string multiLinkId = kvp.Key + ":::0";
+
+
+                    m_model.LinkObj.GetPoints(multiLinkId, ref startId, ref endId);
+                    bhLink.PrimaryNode = new Node { Name = startId };   //Dummy startnode with correct Id
+
+                    List<string> endIds = new List<string>();
+                    for (int i = 1; i < kvp.Value.Count(); i++)
+                    {
+                        multiLinkId = kvp.Key + ":::" + i;
+                        m_model.LinkObj.GetPoints(multiLinkId, ref startId, ref endId);
+                        endIds.Add(endId);
+                    }
+
+                    bhLink.SecondaryNodes = endIds.Select(x => new Node { Name = x }).ToList(); //Dummy endnodes with correct Id
+                }
+                string propName = "";
+                m_model.LinkObj.GetProperty(kvp.Key, ref propName);
+
+                bhLink.Constraint = new LinkConstraint { Name = propName }; //Dummy constraint to be populated in later loop
+
+                /* Get the ETABS name of the Rigid Link */
+                string name = GetAdapterId<string>(bhLink);
+
+
+                // Get the groups the link is assigned to
+                int numGroups = 0;
+                string[] groupNames = new string[0];
+                if (m_model.LinkObj.GetGroupAssign(name, ref numGroups, ref groupNames) == 0)
+                {
+                    foreach (string grpName in groupNames)
+                        bhLink.Tags.Add(grpName);
+                }
+
+                linkList.Add(bhLink);
             }
-            else
+
+            if (linkList.Count == 0)
+                return linkList;
+
+            //Get ids of primary and secondary nodes
+            List<string> nodeIds = linkList.SelectMany(x => x.SecondaryNodes.Select(s => s.Name).Concat(new List<string> { x.PrimaryNode.Name })).Distinct().ToList();
+            Dictionary<string, Node> nodes = GetCachedOrReadAsDictionary<string, Node>(nodeIds);
+
+            List<string> contstrainIds = linkList.Select(x => x.Constraint.Name).Distinct().ToList();
+            //Get cached or read out all constraints used by Links
+            Dictionary<string, LinkConstraint> constraints = contstrainIds.Any() ? new Dictionary<string, LinkConstraint>() : GetCachedOrReadAsDictionary<string, LinkConstraint>(contstrainIds);
+
+            foreach (RigidLink link in linkList)
             {
-                return joinedLinks.Values.ToList();
+                LinkConstraint constraint;  //Reasign cached/read contraint
+                if (constraints.TryGetValue(link.Constraint.Name, out constraint))
+                    link.Constraint = constraint;
+
+                Node stNode;
+                if (nodes.TryGetValue(link.PrimaryNode.Name, out stNode))
+                    link.PrimaryNode = stNode;
+
+                for (int i = 0; i < link.SecondaryNodes.Count; i++)
+                {
+                    Node secNode;
+                    if (nodes.TryGetValue(link.SecondaryNodes[i].Name, out secNode))
+                        link.SecondaryNodes[i] = secNode;
+                }
             }
+
+
+            return linkList;
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/CRUD/Read/_IRead.cs
+++ b/SAP2000_Adapter/CRUD/Read/_IRead.cs
@@ -166,6 +166,19 @@ namespace BH.Adapter.SAP2000
         }
 
         /***************************************************/
+
+        [Description("Extracts the String Name of the BHoM object from the corresponding SAP2000 Unique Name.")]
+        public string GetBhomNameFromSAP2000Id(string id)
+        {
+            if (id.Contains("::"))
+            {
+                string[] splitName = id.Split(new string[] { "::" }, StringSplitOptions.None);
+                return splitName[0];
+            }
+            return id;
+        }
+
+        /***************************************************/
     }
 }
 

--- a/SAP2000_Adapter/CRUD/Update/Bar.cs
+++ b/SAP2000_Adapter/CRUD/Update/Bar.cs
@@ -84,6 +84,7 @@ namespace BH.Adapter.SAP2000
 
                 // Set Properties
                 SetObject(bhBar);
+                UpdateUniqueName(bhBar);
 
             }
             return success;

--- a/SAP2000_Adapter/CRUD/Update/Node.cs
+++ b/SAP2000_Adapter/CRUD/Update/Node.cs
@@ -40,9 +40,13 @@ namespace BH.Adapter.SAP2000
 
             foreach (Node bhNode in nodes)
             {
+                // Update the node object and its unique name
+                SetObject(bhNode);
+                UpdateUniqueName(bhNode);
+
+                // Retrieve node's updated unique name
                 string name = GetAdapterId<string>(bhNode);
 
-                SetObject(bhNode);
 
                 double x = 0;
                 double y = 0;

--- a/SAP2000_Adapter/CRUD/Update/Panel.cs
+++ b/SAP2000_Adapter/CRUD/Update/Panel.cs
@@ -1,0 +1,91 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Adapter;
+using BH.Engine.Structure;
+using BH.oM.Adapter;
+using BH.oM.Adapters.SAP2000;
+using BH.oM.Architecture.Theatron;
+using BH.oM.Geometry;
+using BH.oM.Structure.Elements;
+using CSiAPIv1;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Adapter.SAP2000
+{
+    public partial class SAP2000Adapter : BHoMAdapter
+    {
+        /***************************************************/
+        /**** Update Panel                              ****/
+        /***************************************************/
+
+        private bool UpdateObjects(IEnumerable<Panel> bhPanels)
+        {
+            //Make sure Diaphragms are pushed
+            //List<Diaphragm> diaphragms = bhPanels.Select(x => x.Diaphragm()).Where(x => x != null).ToList();
+            //this.FullCRUD(diaphragms, PushType.FullPush);
+
+            bool success = true;
+            m_model.SelectObj.ClearSelection();
+
+            foreach (Panel bhPanel in bhPanels)
+            {
+                string name = GetAdapterId<string>(bhPanel);
+                string propertyName = GetAdapterId<string>(bhPanel.Property);
+
+                Engine.Base.Compute.RecordWarning("The SAP2000 API does not allow for updating of the geometry of panels. This includes the external edges as well as the openings. To update the panel geometry, delete the existing panel you want to update and create a new one.");
+
+                m_model.AreaObj.SetProperty(name, propertyName);
+
+                //Set local orientations:
+                Basis orientation = bhPanel.LocalOrientation();
+                //m_model.AreaObj.SetLocalAxes(name, Convert.ToEtabsPanelOrientation(orientation.Z, orientation.Y));
+
+                //Diaphragm diaphragm = bhPanel.Diaphragm();
+
+                //if (diaphragm != null)
+                //{
+                //    m_model.AreaObj.SetDiaphragm(name, diaphragm.Name);
+                //}
+
+                //Update Unique Name
+                UpdateUniqueName(bhPanel);
+
+                //Update Groups Assignment
+                //if (!UpdateGroup(bhPanel)) success = false;
+
+            }
+
+            //Force refresh to make sure panel local orientation are set correctly
+            ForceRefresh();
+
+            return success;
+        }
+
+        /***************************************************/
+    }
+}
+
+
+
+

--- a/SAP2000_Adapter/CRUD/Update/_IUpdate.cs
+++ b/SAP2000_Adapter/CRUD/Update/_IUpdate.cs
@@ -20,12 +20,14 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Adapter;
 using BH.oM.Adapter;
-using BH.oM.Base;
-using System.Collections.Generic;
 using BH.oM.Adapters.SAP2000;
+using BH.oM.Base;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SectionProperties;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace BH.Adapter.SAP2000
@@ -55,6 +57,47 @@ namespace BH.Adapter.SAP2000
         private bool UpdateObjects(IEnumerable<IBHoMObject> objects)
         {
             return base.IUpdate(objects, null);
+        }
+
+        /***************************************************/
+
+        [Description("Concatenates the last 7 characters of the SAP2000 Element GUID and the Node Name to get the Unique Name to assign to the SAP2000 Element.")]
+        private bool UpdateUniqueName(BHoMObject obj)
+        {
+            int ret01 = 1;
+            int ret02 = 1;
+            string guid = null;
+            string tempObjName = "";
+
+            /* 1. GET THE SAP2000 ELEMENT GUID */
+            string uniqueName = GetAdapterId<string>(obj);
+
+            if (obj.GetType() == typeof(Node)) ret01 = m_model.PointObj.GetGUID(uniqueName, ref guid);
+            if (obj.GetType() == typeof(Bar)) ret01 = m_model.FrameObj.GetGUID(uniqueName, ref guid);
+            if (obj.GetType() == typeof(Panel) || obj.GetType() == typeof(Opening)) ret01 = m_model.AreaObj.GetGUID(uniqueName, ref guid);
+
+            /* 2. CREATE THE NEW UNIQUE NAME */
+            if (obj.Name == "")
+            {
+                tempObjName = guid.Substring(guid.Length - 7);
+            }
+            else
+            {
+                tempObjName = obj.Name + "::" + guid.Substring(guid.Length - 7);
+            }
+
+            /* 3. ASSIGN THE NEW UNIQUE NAME TO THE SAP2000 ELEMENT */
+            if (obj.GetType() == typeof(Node)) ret02 = m_model.PointObj.ChangeName(uniqueName, tempObjName);
+            if (obj.GetType() == typeof(Bar)) ret02 = m_model.FrameObj.ChangeName(uniqueName, tempObjName);
+            if (obj.GetType() == typeof(Panel) || obj.GetType() == typeof(Opening)) ret02 = m_model.AreaObj.ChangeName(uniqueName, tempObjName);
+
+            if (!(ret01 == 0 && ret02 == 0)) return false;
+
+            SAP2000Id SAP2000IdFragment = new SAP2000Id { Id = tempObjName };
+
+            obj.SetAdapterId(SAP2000IdFragment);
+
+            return true;
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/CRUD/Update/_IUpdate.cs
+++ b/SAP2000_Adapter/CRUD/Update/_IUpdate.cs
@@ -77,7 +77,7 @@ namespace BH.Adapter.SAP2000
             if (obj.GetType() == typeof(Panel) || obj.GetType() == typeof(Opening)) ret01 = m_model.AreaObj.GetGUID(uniqueName, ref guid);
 
             /* 2. CREATE THE NEW UNIQUE NAME */
-            if (obj.Name == "")
+            if (obj.Name == "" || obj.Name == guid.Substring(guid.Length - 7))
             {
                 tempObjName = guid.Substring(guid.Length - 7);
             }

--- a/SAP2000_Adapter/SAP2000Adapter.cs
+++ b/SAP2000_Adapter/SAP2000Adapter.cs
@@ -167,6 +167,16 @@ namespace BH.Adapter.SAP2000
         private cSapModel m_model;
 
         /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private bool ForceRefresh()
+        {
+            int ret0, ret1;
+            ret0 = m_model.View.RefreshView(0,false);
+            ret1 = m_model.View.RefreshWindow(0);
+            return (ret0==1 && ret1==1);
+        }
     }
 }
 

--- a/SAP2000_Adapter/SAP2000_Adapter.csproj
+++ b/SAP2000_Adapter/SAP2000_Adapter.csproj
@@ -73,7 +73,7 @@
     </Reference>
     <Reference Include="CSiAPIv1">
       <HintPath>..\libs\v26\CSiAPIv1.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Data_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Data_oM.dll</HintPath>
@@ -142,7 +142,7 @@
     </Reference>
     <Reference Include="SAP2000v1">
       <HintPath>..\libs\v26\SAP2000v1.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Serialiser_Engine">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
@@ -232,6 +232,7 @@
     <Compile Include="CRUD\Read\RigidLink.cs" />
     <Compile Include="CRUD\Read\Section.cs" />
     <Compile Include="CRUD\Read\SurfaceProperty.cs" />
+    <Compile Include="CRUD\Update\Panel.cs" />
     <Compile Include="CRUD\Update\Bar.cs" />
     <Compile Include="CRUD\Update\Section.cs" />
     <Compile Include="CRUD\Update\Material.cs" />


### PR DESCRIPTION
### Issues addressed by this PR

Fixes #342 

<img width="1898" height="802" alt="Grasshopper Script View" src="https://github.com/user-attachments/assets/6d46c2b5-bf55-4c26-955a-6142d3f1056e" />

<img width="1412" height="838" alt="SAP2000 Model View" src="https://github.com/user-attachments/assets/aa66509c-fc50-46a9-9985-b69a86770723" />


SAP2000 Toolkit now allows to push/pull and update objects (i.e. bars, nodes, panels and rigid links) handling corresponding assignments to SAP2000 Unique Name via BHoM Name.

### Test files

Grasshopper File
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/SAP2000_Toolkit/%23349-AddSupportForObjectNames?csf=1&web=1&e=NNSa2B

### Changelog
- Add Support for UniqueName Assignment in Push/Pull/Update of Bars
- Add Support for UniqueName Assignment in Push/Pull/Update of Nodes
- Add Support for UniqueName Assignment in Push/Pull/Update of Panels
- Add Support for UniqueName Assignment in Push/Pull/Update of Links
