### PR TITLE
Add Support for Joint Velocities and Accelerations

### DIFF
--- a/SAP2000_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/BarResults.cs
@@ -248,6 +248,22 @@ namespace BH.Adapter.SAP2000
         /**** Private method - Extraction methods       ****/
         /***************************************************/
 
+        private List<string> CheckGetBarIds(IStructuralResultRequest request)
+        {
+            List<string> barIds = CheckAndGetIds<Bar>(request.ObjectIds);
+
+            if (barIds == null || barIds.Count == 0)
+            {
+                int bars = 0;
+                string[] names = null;
+                m_model.FrameObj.GetNameList(ref bars, ref names);
+                barIds = names.ToList();
+            }
+            return barIds;
+        }
+
+        /***************************************************/
+
         private double GetBarLength(string barId, Dictionary<string, Point> pts)
         {
             string p1Id = "";

--- a/SAP2000_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/BarResults.cs
@@ -73,7 +73,7 @@ namespace BH.Adapter.SAP2000
         private List<BarDisplacement> ReadBarDisplacements(List<string> barIds = null,
                                                            int divisions = 0)
         {
-            List<BarDisplacement> displacements  = new List<BarDisplacement>();
+            List<BarDisplacement> displacements = new List<BarDisplacement>();
             if (divisions != 0)
             {
                 Engine.Base.Compute.RecordWarning("Displacements will only be extracted at SAP2000 calculation nodes." +

--- a/SAP2000_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/BarResults.cs
@@ -46,7 +46,7 @@ namespace BH.Adapter.SAP2000
         {
             CheckAndSetUpCases(request);
 
-            List<string> barIds = CheckGetBarIds(request);
+            List<string> barIds = CheckAndGetIds<Bar>(request);
 
             switch (request.ResultType)
             {

--- a/SAP2000_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/BarResults.cs
@@ -248,22 +248,6 @@ namespace BH.Adapter.SAP2000
         /**** Private method - Extraction methods       ****/
         /***************************************************/
 
-        private List<string> CheckGetBarIds(IStructuralResultRequest request)
-        {
-            List<string> barIds = CheckAndGetIds<Bar>(request.ObjectIds);
-
-            if (barIds == null || barIds.Count == 0)
-            {
-                int bars = 0;
-                string[] names = null;
-                m_model.FrameObj.GetNameList(ref bars, ref names);
-                barIds = names.ToList();
-            }
-            return barIds;
-        }
-
-        /***************************************************/
-
         private double GetBarLength(string barId, Dictionary<string, Point> pts)
         {
             string p1Id = "";

--- a/SAP2000_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -245,23 +245,6 @@ namespace BH.Adapter.SAP2000
         /**** Private method - Support methods          ****/
         /***************************************************/
 
-        private List<string> CheckGetNodeIds(NodeResultRequest request)
-        {
-            List<string> nodeIds = CheckAndGetIds<Node>(request.ObjectIds);
-
-            if (nodeIds == null || nodeIds.Count == 0)
-            {
-                int nodes = 0;
-                string[] names = null;
-                m_model.PointObj.GetNameList(ref nodes, ref names);
-                nodeIds = names.ToList();
-            }
-
-            return nodeIds;
-        }
-
-        /***************************************************/
-
     }
 }
 

--- a/SAP2000_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -44,7 +44,7 @@ namespace BH.Adapter.SAP2000
                                                 ActionConfig actionConfig = null)
         {
             CheckAndSetUpCases(request);
-            List<string> nodeIds = CheckGetNodeIds(request);
+            List<string> nodeIds = CheckAndGetIds<Node>(request);
 
             switch (request.ResultType)
             {

--- a/SAP2000_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -29,6 +29,7 @@ using BH.oM.Analytical.Results;
 using BH.oM.Structure.Requests;
 using BH.oM.Adapter;
 using SAP2000v1;
+using BH.oM.Structure.Elements;
 
 
 namespace BH.Adapter.SAP2000
@@ -52,7 +53,9 @@ namespace BH.Adapter.SAP2000
                 case NodeResultType.NodeDisplacement:
                     return ReadNodeDisplacement(nodeIds);
                 case NodeResultType.NodeAcceleration:
+                    return ReadNodeAcceleration(nodeIds);
                 case NodeResultType.NodeVelocity:
+                    return ReadNodeVelocity(nodeIds);
                 default:
                     Engine.Base.Compute.RecordError("Result extraction of type " + request.ResultType + " is not yet supported");
                     return new List<IResult>();
@@ -63,14 +66,46 @@ namespace BH.Adapter.SAP2000
         /**** Private method - Extraction methods       ****/
         /***************************************************/
 
-        private List<NodeResult> ReadNodeAcceleration(IList ids = null,
-                                                      IList cases = null)
+        private List<NodeAcceleration> ReadNodeAcceleration(List<string> nodeIds)
         {
-            throw new NotImplementedException("Node Acceleration results is not supported yet!");
 
+            List<NodeAcceleration> nodeAccelerations = new List<NodeAcceleration>();
+
+            int resultCount = 0;
+            string[] loadcaseNames = null;
+            string[] objects = null;
+            string[] elm = null;
+            string[] stepType = null;
+            double[] stepNum = null;
+            double[] ux = null;
+            double[] uy = null;
+            double[] uz = null;
+            double[] rx = null;
+            double[] ry = null;
+            double[] rz = null;
+
+            for (int i = 0; i < nodeIds.Count; i++)
+            {
+                int ret = m_model.Results.JointAccAbs(nodeIds[i].ToString(), eItemTypeElm.ObjectElm, ref resultCount, ref objects, ref elm, ref loadcaseNames,
+                                                      ref stepType, ref stepNum, ref ux, ref uy, ref uz, ref rx, ref ry, ref rz);
+                if (ret == 0)
+                {
+                    for (int j = 0; j < resultCount; j++)
+                    {
+                        int mode;
+                        double timeStep;
+                        GetStepAndMode(stepType[j], stepNum[j], out timeStep, out mode);
+                        NodeAcceleration na = new NodeAcceleration(nodeIds[i], loadcaseNames[j], mode, timeStep, oM.Geometry.Basis.XY, ux[j], uy[j], uz[j], rx[j], ry[j], rz[j]);
+                        nodeAccelerations.Add(na);
+                    }
+                }
+            }
+
+            return nodeAccelerations;
         }
 
         /***************************************************/
+
         private List<NodeDisplacement> ReadNodeDisplacement(List<string> nodeIds)
         {
 
@@ -169,17 +204,63 @@ namespace BH.Adapter.SAP2000
 
         /***************************************************/
 
-        
-        private List<NodeResult> ReadNodeVelocity(IList ids = null,
-                                                  IList cases = null)
+        private List<NodeVelocity> ReadNodeVelocity(List<string> nodeIds)
         {
-            throw new NotImplementedException("Node velocity results are not supported yet!");
+            List<NodeVelocity> nodeVelocities = new List<NodeVelocity>();
 
+            int resultCount = 0;
+            string[] loadcaseNames = null;
+            string[] objects = null;
+            string[] elm = null;
+            string[] stepType = null;
+            double[] stepNum = null;
+            double[] ux = null;
+            double[] uy = null;
+            double[] uz = null;
+            double[] rx = null;
+            double[] ry = null;
+            double[] rz = null;
+
+            for (int i = 0; i < nodeIds.Count; i++)
+            {
+                int ret = m_model.Results.JointVelAbs(nodeIds[i], eItemTypeElm.ObjectElm, ref resultCount, ref objects, ref elm,
+                                                      ref loadcaseNames, ref stepType, ref stepNum, ref ux, ref uy, ref uz, ref rx, ref ry, ref rz);
+                if (ret == 0)
+                {
+                    for (int j = 0; j < resultCount; j++)
+                    {
+                        int mode;
+                        double timeStep;
+                        GetStepAndMode(stepType[j], stepNum[j], out timeStep, out mode);
+                        NodeVelocity nv = new NodeVelocity(nodeIds[i], loadcaseNames[j], mode, timeStep, oM.Geometry.Basis.XY, ux[j], uy[j], uz[j], rx[j], ry[j], rz[j]);
+                        nodeVelocities.Add(nv);
+                    }
+                }
+            }
+
+            return nodeVelocities;
         }
+
         /***************************************************/
         /**** Private method - Support methods          ****/
         /***************************************************/
 
+        private List<string> CheckGetNodeIds(NodeResultRequest request)
+        {
+            List<string> nodeIds = CheckAndGetIds<Node>(request.ObjectIds);
+
+            if (nodeIds == null || nodeIds.Count == 0)
+            {
+                int nodes = 0;
+                string[] names = null;
+                m_model.PointObj.GetNameList(ref nodes, ref names);
+                nodeIds = names.ToList();
+            }
+
+            return nodeIds;
+        }
+
+        /***************************************************/
 
     }
 }

--- a/SAP2000_Adapter/CRUD/Read/Results/Result.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/Result.cs
@@ -20,15 +20,16 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapter;
+using BH.oM.Analytical.Results;
+using BH.oM.Base;
+using BH.oM.Data.Requests;
+using BH.oM.Structure.Loads;
+using BH.oM.Structure.Requests;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using BH.oM.Analytical.Results;
-using BH.oM.Structure.Loads;
-using BH.oM.Data.Requests;
-using BH.oM.Structure.Requests;
-using BH.oM.Adapter;
 
 namespace BH.Adapter.SAP2000
 {
@@ -108,15 +109,21 @@ namespace BH.Adapter.SAP2000
             return true;
         }
 
-        /***************************************************/
-        private List<string> CheckGetBarIds(IStructuralResultRequest request)
-        {
-            int sapBarCount = 0;
-            string[] sapBarIds = null;
-            m_model.FrameObj.GetNameList(ref sapBarCount, ref sapBarIds);
 
-            //Get the bar ids which are valid
-            return FilterIds(request.ObjectIds.Select(x => x.ToString()), sapBarIds);
+        /***************************************************/
+
+        private void GetStepAndMode(string stepType, double stepNum, out double timeStep, out int mode)
+        {
+            if (stepType == "Mode")
+            {
+                mode = (int)stepNum;
+                timeStep = 0;
+            }
+            else
+            {
+                timeStep = stepNum;
+                mode = 0;
+            }
         }
 
         /***************************************************/

--- a/SAP2000_Adapter/CRUD/Read/Results/Result.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/Result.cs
@@ -128,14 +128,33 @@ namespace BH.Adapter.SAP2000
 
         /***************************************************/
 
-        private List<string> CheckGetNodeIds(NodeResultRequest request)
+        private List<string> CheckAndGetIds<T>(IEnumerable ids) where T : IBHoMObject
         {
-            int sapNodeCount = 0;
-            string[] sapNodeIds = null;
-            m_model.PointObj.GetNameList(ref sapNodeCount, ref sapNodeIds);
-
-            return FilterIds(request.ObjectIds.Select(x => x.ToString()), sapNodeIds);
+            if (ids == null)
+            {
+                return null;
+            }
+            else
+            {
+                List<string> idsOut = new List<string>();
+                foreach (object o in ids)
+                {
+                    if (o is string)
+                        idsOut.Add((string)o);
+                    else if (o is int || o is double)
+                        idsOut.Add(o.ToString());
+                    else if (o is T)
+                    {
+                        string id = GetAdapterId<string>((T)o);
+                        if (id != null)
+                            idsOut.Add(id);
+                    }
+                }
+                return idsOut;
+            }
         }
+
+        /***************************************************/
     }
 }
 

--- a/SAP2000_Adapter/CRUD/Read/Results/Result.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/Result.cs
@@ -114,6 +114,14 @@ namespace BH.Adapter.SAP2000
 
         private void GetStepAndMode(string stepType, double stepNum, out double timeStep, out int mode)
         {
+            /* Based on ETABS API outputs data structure, depending on the value of stepType, the stepNum parameter
+             * has a different meaning. 
+             * If stepType = "Mode", stepNum is assigned with the number of the corresponding Mode, otherwise it is 
+             * assigned with the value of the timeStep.
+             * Hence, the output parameters timeStep and mode are assigned with values based on a different logic
+             * as in the below if statement.
+             */
+            
             if (stepType == "Mode")
             {
                 mode = (int)stepNum;

--- a/SAP2000_Adapter/CRUD/Read/Results/Result.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/Result.cs
@@ -24,9 +24,11 @@ using BH.oM.Adapter;
 using BH.oM.Analytical.Results;
 using BH.oM.Base;
 using BH.oM.Data.Requests;
+using BH.oM.Structure.Elements;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Requests;
 using System;
+using System.CodeDom;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -163,6 +165,51 @@ namespace BH.Adapter.SAP2000
         }
 
         /***************************************************/
+
+        private List<string> CheckAndGetIds<T>(IResultRequest request) where T : IBHoMObject
+        {
+            List<string> ids = new List<string>();
+
+            if (request.ObjectIds == null)
+            {
+                return null;
+            }
+            else
+            {
+                foreach (object o in request.ObjectIds)
+                {
+                    if (o is string)
+                        ids.Add((string)o);
+                    else if (o is int || o is double)
+                        ids.Add(o.ToString());
+                    else if (o is T)
+                    {
+                        string id = GetAdapterId<string>((T)o);
+                        if (id != null)
+                            ids.Add(id);
+                    }
+                }
+            }
+
+            string[] names = null;
+
+            switch (typeof(T))
+            {
+                case Type t when t == typeof(Node):
+                    int nodes = 0;
+                    m_model.PointObj.GetNameList(ref nodes, ref names);
+                    break;
+                case Type t when t == typeof(Bar):
+                    int bars = 0;
+                    m_model.FrameObj.GetNameList(ref bars, ref names);
+                    break;
+                default:
+                    names = new string[] { };
+                    break;
+            }
+
+            return names.ToList();
+        }
     }
 }
 

--- a/SAP2000_Adapter/CRUD/Read/Results/SteelUtilisationResults.cs
+++ b/SAP2000_Adapter/CRUD/Read/Results/SteelUtilisationResults.cs
@@ -35,6 +35,7 @@ using BH.oM.Adapter;
 using BH.oM.Adapters.SAP2000.Results;
 using BH.oM.Adapters.SAP2000.Requests;
 using SAP2000v1;
+using BH.oM.Structure.Elements;
 
 
 namespace BH.Adapter.SAP2000
@@ -49,7 +50,7 @@ namespace BH.Adapter.SAP2000
                                                 ActionConfig actionConfig = null)
         {
             CheckAndSetUpCases(request);
-            List<string> barIds = CheckGetBarIds(request);
+            List<string> barIds = CheckAndGetIds<Bar>(request);
 
             switch (request.Code)
             {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Fixes #326 #327

<img width="1375" height="870" alt="GH Script - Success - After Pull Request" src="https://github.com/user-attachments/assets/1b95c118-e2d4-4353-a2eb-a7575598a54e" />

<img width="1327" height="897" alt="SAP2000 Velocity Outputs - Success" src="https://github.com/user-attachments/assets/97c9ca24-0053-4e47-a870-a6b45413f8ed" />

<img width="1319" height="901" alt="SAP2000 Acceleration Outputs - Success" src="https://github.com/user-attachments/assets/69d35351-dad6-4b02-b46f-19effe761a33" />

<br />
<br />

SAP2000 Toolkit now can be used to extract joint velocity and acceleration outputs from SAP2000.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/SAP2000_Toolkit/%23351-AddSupportForJointVelocitiesAndAccelerations?d=w49d963786f4747afa2e62d9bd2d22ad4&csf=1&web=1&e=oakKn0


### Changelog
- Added ReadNodeVelocity Method to retrieve Abs Joint Velocities from SAP2000
- - Added ReadNodeAcceleration Method to retrieve Abs Joint Accelerations from SAP2000