### PR TITLE
expand reference to resolve conflict

### DIFF
--- a/SAP2000_Adapter/Convert/ToBHoM/Panel.cs
+++ b/SAP2000_Adapter/Convert/ToBHoM/Panel.cs
@@ -42,7 +42,7 @@ namespace BH.Adapter.SAP2000
         {
             Vector locYref;
 
-            if (Query.IsParallel(normal, Vector.ZAxis)!=0)
+            if (BH.Engine.Geometry.Query.IsParallel(normal, Vector.ZAxis)!=0)
             {
                 //Vector is paralell to z-axis
                 locYref = Vector.YAxis;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #359 

<!-- Add short description of what has been fixed -->

Expanded single Query reference to its full path to resolve conflict between Geometry.Query() & Units.Query(). New Units.Query() method added in Localisation_Toolkit introduces this conflict.

https://github.com/BHoM/Localisation_Toolkit/pull/181

` if (Query.IsParallel(normal, Vector.ZAxis)!=0)`

now reads

`if (BH.Engine.Geometry.Query.IsParallel(normal, Vector.ZAxis)!=0)`

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/SAP2000_Toolkit/%23360-ExpandReferenceToResolveConflict?d=wfdb3817de2054fb38a5ce621ed661e1e&csf=1&web=1&e=qPHmca

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->